### PR TITLE
Fixed service unit file spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ In the `src` folder, it contained a file called `wg-dashboard.service`, we can u
 
    ```ini
    [Unit]
-   After=netword.service
+   After=network.service
    
    [Service]
    WorkingDirectory=<your dashboard directory full path here>


### PR DESCRIPTION
"netword.service" to "network.service"