### PR TITLE
Updated README to include username/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@
 
 6. Access dashboard
 
-   Access your server with port `10086` ! e.g (http://your_server_ip:10086), continue to read to on how to change port and ip that dashboard is running with.
+   Access your server with port `10086` (e.g. http://your_server_ip:10086), using username `admin` and password `admin`. See below how to change port and ip that the dashboard is running with.
 
 ## 🪜 Usage
 


### PR DESCRIPTION
Updated Installation instructions to include default username/password in step 6 on login. It is located in the 'Dashboard Configuration' section, however for readability/ease of setting up the server, I added the default login to the install instructions.