### PR TITLE
fixed Label for Username overlaps the username

### DIFF
--- a/src/static/css/dashboard.css
+++ b/src/static/css/dashboard.css
@@ -419,7 +419,7 @@ main{
 label[for="username"], label[for="password"]{
     font-size: 1rem;
     margin: 0 !important;
-    transform: translateY(30px) translateX(16px);
+    /* transform: translateY(30px) translateX(16px); */
     padding: 0;
 }
 


### PR DESCRIPTION
On the settings page the label for username overlaps the username.
fixed it by disabling the transform css

checked signin.html template file where the label is also used - no side effects.