### PR TITLE
Error when the default interface ip cannot be found!

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1637,8 +1637,13 @@ def init_dashboard():
         config['Peers']['peer_endpoint_allowed_ip'] = '0.0.0.0/0'
     if 'peer_display_mode' not in config['Peers']:
         config['Peers']['peer_display_mode'] = 'grid'
-    if 'remote_endpoint' not in config['Peers']:
-        config['Peers']['remote_endpoint'] = ifcfg.default_interface()['inet']
+    if 'remote_endpoint' not in config['Peers']:        
+        try:
+            default_inet = ifcfg.default_interface()['inet']
+            config['Peers']['remote_endpoint'] = default_inet
+        except:
+            print("Default interface ip for remote endpoint not found!")
+            config['Peers']['remote_endpoint'] = str(input("Please enter remote endpoint: ")) #ifcfg.default_interface()['inet']
     if 'peer_MTU' not in config['Peers']:
         config['Peers']['peer_MTU'] = "1420"
     if 'peer_keep_alive' not in config['Peers']:


### PR DESCRIPTION
I've installed this great dashboard on my VPS and noticed that when my Linux Machine default route is set to tunnel interface, the "ifcfg.default_interface()" function returns "None" and the program crashes. 
I am a junior Python developer and I made some changes to solve this problem.
Please let me know if you have any comments.


-------------------ERROR-------------------
------------------------------------------------------------
| Starting WGDashboard with Gunicorn in the background.    |
Failed to read config file: /root/wgdashboard/src/gunicorn.conf.py
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/gunicorn/app/base.py", line 111, in get_config_from_filename
    spec.loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/wgdashboard/src/gunicorn.conf.py", line 4, in <module>
    app_host, app_port = dashboard.get_host_bind()
  File "/root/wgdashboard/src/dashboard.py", line 1702, in get_host_bind
    init_dashboard()
  File "/root/wgdashboard/src/dashboard.py", line 1641, in init_dashboard
    config['Peers']['remote_endpoint'] = ifcfg.default_interface()['inet']
TypeError: 'NoneType' object is not subscriptable
| Log files is under log/