### PR TITLE
updated docker compatibility in v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN  cd / && echo "[Interface]" > wg0.conf && echo "SaveConfig = true" >> wg0.co
 
 COPY ./src /opt/wgdashboard_tmp
 RUN pip3 install -r /opt/wgdashboard_tmp/requirements.txt   --no-cache-dir
+# install requirements for old dashboard
+RUN pip3 install -r /opt/wgdashboard_tmp/requirements_old.txt   --no-cache-dir
 RUN rm -rf /opt/wgdashboard_tmp
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod u+x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG WG_ADDRESS=$WG_ADDRESS
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     build: 
       context: ./
       dockerfile: ./Dockerfile
+    # if you want to use newer "testing" ui
+    # environment:
+    #   - DASHBOARD_VERSON=new
     cap_add: 
       - NET_ADMIN
       - SYS_MODULE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,11 +11,11 @@
 # if they choose to run old
 if [[ ${DASHBOARD_VERSON^^} == "NEW" ]] ; then
   echo "Using newer dashboard"
-  cp dashboard.py dashboard_old.py
-  cp dashboard_new.py dashboard.py
+  cp /opt/wgdashboard/dashboard.py /opt/wgdashboard/dashboard_old.py
+  cp /opt/wgdashboard/dashboard_new.py /opt/wgdashboard/dashboard.py
 else
   echo "Defaulting to old dashboard"
-  if ! $(cp dashboard_old.py dashboard.py 2>/dev/null) ; then
+  if ! $(cp /opt/wgdashboard/dashboard_old.py /opt/wgdashboard/dashboard.py 2>/dev/null) ; then
     echo "No dashboard_old.py file, assuming dashboard.py version is old"
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,18 @@
 #   echo "Removed unneeded conf file"
 # fi
 
+# if they choose to run old
+if [[ ${DASHBOARD_VERSON^^} == "NEW" ]] ; then
+  echo "Using newer dashboard"
+  cp dashboard.py dashboard_old.py
+  cp dashboard_new.py dashboard.py
+else
+  echo "Defaulting to old dashboard"
+  if ! $(cp dashboard_old.py dashboard.py 2>/dev/null) ; then
+    echo "No dashboard_old.py file, assuming dashboard.py version is old"
+  fi
+fi
+
 # wg-quick up wg0
 chmod u+x /opt/wgdashboard/wgd.sh
 if [ ! -f "/opt/wgdashboard/wg-dashboard.ini" ]; then

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1240,7 +1240,7 @@ def add_peer(config_name):
         return "Please fill in all required box."
     if not isinstance(keys, list):
         return config_name + " is not running."
-    if public_key in keys:d;lp
+    if public_key in keys:
         return "Public key already exist."
     check_dup_ip = g.cur.execute(
         "SELECT COUNT(*) FROM " + config_name + " WHERE allowed_ip LIKE '" + allowed_ips + "/%'", ) \

--- a/src/requirements_old.txt
+++ b/src/requirements_old.txt
@@ -1,0 +1,1 @@
+flask_qrcode


### PR DESCRIPTION
In v4 the docker would not run unless it was modified. The dashboard.py had a typo in it that needed to be fixed. The requirements were updated to work with dashboard_new.py, but ended up removing needed requirements for dashboard.py. 

The big changes mad in this pull request was adding handling in the entrypoint.sh via environment variable to be able to run either the dashboard.py or dashboad_new.py. In the docker-compose.yml it shows the lines you need if you want to use the newer dashboard.