### PR TITLE
v4 Draft: Add url prefix. like http://localhost:10086/url_prefix

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -33,6 +33,9 @@ from flask.json.provider import DefaultJSONProvider
 
 DASHBOARD_VERSION = 'v4.0'
 CONFIGURATION_PATH = os.getenv('CONFIGURATION_PATH', '.')
+# Set default URL_PREFIX
+URL_PREFIX = os.getenv('URL_PREFIX', '/')
+
 DB_PATH = os.path.join(CONFIGURATION_PATH, 'db')
 if not os.path.isdir(DB_PATH):
     os.mkdir(DB_PATH)
@@ -47,7 +50,7 @@ UPDATE = None
 app = Flask("WGDashboard")
 app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 5206928
 app.secret_key = secrets.token_urlsafe(32)
-cors = CORS(app, resources={r"/api/*": {
+cors = CORS(app, resources={r"{URL_PREFIX}api/*": {
     "origins": "*",
     "methods": "DELETE, POST, GET, OPTIONS",
     "allow_headers": ["Content-Type", "wg-dashboard-apikey"]

--- a/src/static/app/index.html
+++ b/src/static/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.png">
+    <link rel="icon" href="./favicon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>WGDashboard</title>
   </head>

--- a/src/static/app/public/config.js
+++ b/src/static/app/public/config.js
@@ -1,0 +1,4 @@
+let apiUrl='/api';
+window.config = {
+    apiUrl: '/api'
+  };

--- a/src/static/app/src/components/configurationComponents/peerCreate.vue
+++ b/src/static/app/src/components/configurationComponents/peerCreate.vue
@@ -42,7 +42,7 @@ export default {
 		}
 	},
 	mounted() {
-		fetchGet("/api/getAvailableIPs/" + this.$route.params.id, {}, (res) => {
+		fetchGet(`${apiUrl}/getAvailableIPs/` + this.$route.params.id, {}, (res) => {
 			if (res.status){
 				this.availableIp = res.data;
 			}
@@ -56,7 +56,7 @@ export default {
 	methods: {
 		peerCreate(){
 			this.saving = true
-			fetchPost("/api/addPeers/" + this.$route.params.id, this.data, (res) => {
+			fetchPost(`${apiUrl}/addPeers/` + this.$route.params.id, this.data, (res) => {
 				if (res.status){
 					this.$router.push(`/configuration/${this.$route.params.id}/peers`)
 					this.dashboardStore.newMessage("Server", "Peer create successfully", "success")

--- a/src/static/app/src/components/configurationComponents/peerJobsLogsModal.vue
+++ b/src/static/app/src/components/configurationComponents/peerJobsLogsModal.vue
@@ -24,7 +24,7 @@ export default {
 	methods: {
 		async fetchLog(){
 			this.dataLoading = true;
-			await fetchGet(`/api/getPeerScheduleJobLogs/${this.configurationInfo.Name}`, {}, (res) => {
+			await fetchGet(`${apiUrl}/getPeerScheduleJobLogs/${this.configurationInfo.Name}`, {}, (res) => {
 				this.data = res.data;
 				this.logFetchTime = dayjs().format("YYYY-MM-DD HH:mm:ss")
 				this.dataLoading = false;

--- a/src/static/app/src/components/configurationComponents/peerList.vue
+++ b/src/static/app/src/components/configurationComponents/peerList.vue
@@ -169,7 +169,7 @@ export default {
 	methods:{
 		toggle(){
 			this.configurationToggling = true;
-			fetchGet("/api/toggleWireguardConfiguration/", {
+			fetchGet(`${apiUrl}/toggleWireguardConfiguration/`, {
 				configurationName: this.configurationInfo.Name
 			}, (res) => {
 				if (res.status){
@@ -185,7 +185,7 @@ export default {
 			})
 		},
 		getPeers(id = this.$route.params.id){
-			fetchGet("/api/getWireguardConfigurationInfo",
+			fetchGet(`${apiUrl}/getWireguardConfigurationInfo`,
 				{
 					configurationName: id
 				}, (res) => {

--- a/src/static/app/src/components/configurationComponents/peerScheduleJobsComponents/schedulePeerJob.vue
+++ b/src/static/app/src/components/configurationComponents/peerScheduleJobsComponents/schedulePeerJob.vue
@@ -45,7 +45,7 @@ export default {
 	methods: {
 		save(){
 			if (this.job.Field && this.job.Operator && this.job.Action && this.job.Value){
-				fetchPost(`/api/savePeerScheduleJob/`, {
+				fetchPost(`${apiUrl}/savePeerScheduleJob/`, {
 					Job: this.job
 				}, (res) => {
 					if (res.status){
@@ -83,7 +83,7 @@ export default {
 		},
 		delete(){
 			if(this.job.CreationDate){
-				fetchPost(`/api/deletePeerScheduleJob/`, {
+				fetchPost(`${apiUrl}/deletePeerScheduleJob/`, {
 					Job: this.job
 				}, (res) => {
 					if (!res.status){

--- a/src/static/app/src/components/configurationComponents/peerSearch.vue
+++ b/src/static/app/src/components/configurationComponents/peerSearch.vue
@@ -47,7 +47,7 @@ export default {
 			}
 		},
 		updateSort(sort){
-			fetchPost("/api/updateDashboardConfigurationItem", {
+			fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 				section: "Server",
 				key: "dashboard_sort",
 				value: sort
@@ -58,7 +58,7 @@ export default {
 			})
 		},
 		updateRefreshInterval(refreshInterval){
-			fetchPost("/api/updateDashboardConfigurationItem", {
+			fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 				section: "Server",
 				key: "dashboard_refresh_interval",
 				value: refreshInterval
@@ -69,7 +69,7 @@ export default {
 			})
 		},
 		downloadAllPeer(){
-			fetchGet(`/api/downloadAllPeers/${this.configuration.Name}`, {}, (res) => {
+			fetchGet(`${apiUrl}/downloadAllPeers/${this.configuration.Name}`, {}, (res) => {
 				console.log(res);
 				window.wireguard.generateZipFiles(res, this.configuration.Name)
 			})

--- a/src/static/app/src/components/configurationComponents/peerSettings.vue
+++ b/src/static/app/src/components/configurationComponents/peerSettings.vue
@@ -28,7 +28,7 @@ export default {
 		},
 		savePeer(){
 			this.saving = true;
-			fetchPost(`/api/updatePeerSettings/${this.$route.params.id}`, this.data, (res) => {
+			fetchPost(`${apiUrl}/updatePeerSettings/${this.$route.params.id}`, this.data, (res) => {
 				this.saving = false;
 				if (res.status){
 					this.dashboardConfigurationStore.newMessage("Server", "Peer Updated!", "success")
@@ -40,7 +40,7 @@ export default {
 		},
 		resetPeerData(type){
 			this.saving = true
-			fetchPost(`/api/resetPeerData/${this.$route.params.id}`, {
+			fetchPost(`${apiUrl}/resetPeerData/${this.$route.params.id}`, {
 				id: this.data.id,
 				type: type
 			}, (res) => {

--- a/src/static/app/src/components/configurationComponents/peerSettingsDropdown.vue
+++ b/src/static/app/src/components/configurationComponents/peerSettingsDropdown.vue
@@ -20,7 +20,7 @@ export default {
 	},
 	methods: {
 		downloadPeer(){
-			fetchGet("/api/downloadPeer/"+this.$route.params.id, {
+			fetchGet(`${apiUrl}/downloadPeer/`+this.$route.params.id, {
 				id: this.Peer.id
 			}, (res) => {
 				if (res.status){
@@ -38,7 +38,7 @@ export default {
 			})
 		},
 		downloadQRCode(){
-			fetchGet("/api/downloadPeer/"+this.$route.params.id, {
+			fetchGet(`${apiUrl}/downloadPeer/`+this.$route.params.id, {
 				id: this.Peer.id
 			}, (res) => {
 				if (res.status){
@@ -50,7 +50,7 @@ export default {
 		},
 		deletePeer(){
 			this.deleteBtnDisabled = true
-			fetchPost(`/api/deletePeers/${this.$route.params.id}`, {
+			fetchPost(`${apiUrl}/deletePeers/${this.$route.params.id}`, {
 				peers: [this.Peer.id]
 			}, (res) => {
 				this.dashboardStore.newMessage("Server", res.message, res.status ? "success":"danger")
@@ -60,7 +60,7 @@ export default {
 		},
 		restrictPeer(){
 			this.restrictBtnDisabled = true
-			fetchPost(`/api/restrictPeers/${this.$route.params.id}`, {
+			fetchPost(`${apiUrl}/restrictPeers/${this.$route.params.id}`, {
 				peers: [this.Peer.id]
 			}, (res) => {
 				this.dashboardStore.newMessage("Server", res.message, res.status ? "success":"danger")
@@ -70,7 +70,7 @@ export default {
 		},
 		allowAccessPeer(){
 			this.allowAccessBtnDisabled = true
-			fetchPost(`/api/allowAccessPeers/${this.$route.params.id}`, {
+			fetchPost(`${apiUrl}/allowAccessPeers/${this.$route.params.id}`, {
 				peers: [this.Peer.id]
 			}, (res) => {
 				this.dashboardStore.newMessage("Server", res.message, res.status ? "success":"danger")

--- a/src/static/app/src/components/configurationComponents/peerShareLinkModal.vue
+++ b/src/static/app/src/components/configurationComponents/peerShareLinkModal.vue
@@ -41,7 +41,7 @@ export default {
 	methods: {
 		startSharing(){
 			this.loading = true;
-			fetchPost("/api/sharePeer/create", {
+			fetchPost(`${apiUrl}/sharePeer/create`, {
 				Configuration: this.peer.configuration.Name,
 				Peer: this.peer.id,
 				ExpireDate: dayjs().add(7, 'd').format("YYYY-MM-DD HH:mm:ss")
@@ -59,7 +59,7 @@ export default {
 			})
 		},
 		updateLinkExpireDate(){
-			fetchPost("/api/sharePeer/update", this.dataCopy, (res) => {
+			fetchPost(`${apiUrl}/sharePeer/update`, this.dataCopy, (res) => {
 				if (res.status){
 					this.dataCopy = res.data.at(0)
 					this.peer.ShareLink = res.data;

--- a/src/static/app/src/components/configurationListComponents/configurationCard.vue
+++ b/src/static/app/src/components/configurationListComponents/configurationCard.vue
@@ -24,7 +24,7 @@ export default {
 	methods: {
 		toggle(){
 			this.configurationToggling = true;
-			fetchGet("/api/toggleWireguardConfiguration/", {
+			fetchGet(`${apiUrl}/toggleWireguardConfiguration/`, {
 				configurationName: this.c.Name
 			}, (res) => {
 				if (res.status){

--- a/src/static/app/src/components/settingsComponent/accountSettingsInputPassword.vue
+++ b/src/static/app/src/components/settingsComponent/accountSettingsInputPassword.vue
@@ -32,7 +32,7 @@ export default {
 		async useValidation(){
 			if (Object.values(this.value).find(x => x.length === 0) === undefined){
 				if (this.value.newPassword === this.value.repeatNewPassword){
-					await fetchPost("/api/updateDashboardConfigurationItem", {
+					await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 						section: "Account",
 						key: this.targetData,
 						value: this.value

--- a/src/static/app/src/components/settingsComponent/accountSettingsInputUsername.vue
+++ b/src/static/app/src/components/settingsComponent/accountSettingsInputUsername.vue
@@ -34,7 +34,7 @@ export default {
 		async useValidation(){
 			if (this.changed){
 				this.updating = true
-				await fetchPost("/api/updateDashboardConfigurationItem", {
+				await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 					section: "Account",
 					key: this.targetData,
 					value: this.value

--- a/src/static/app/src/components/settingsComponent/accountSettingsMFA.vue
+++ b/src/static/app/src/components/settingsComponent/accountSettingsMFA.vue
@@ -20,12 +20,12 @@ export default {
 	},
 	methods: {
 		async resetMFA(){
-			await fetchPost("/api/updateDashboardConfigurationItem", {
+			await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 				section: "Account",
 				key: "totp_verified",
 				value: "false"
 			}, async (res) => {
-				await fetchPost("/api/updateDashboardConfigurationItem", {
+				await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 					section: "Account",
 					key: "enable_totp",
 					value: "false"

--- a/src/static/app/src/components/settingsComponent/dashboardAPIKeys.vue
+++ b/src/static/app/src/components/settingsComponent/dashboardAPIKeys.vue
@@ -21,7 +21,7 @@ export default {
 	},
 	methods: {
 		async toggleDashboardAPIKeys(){
-			await fetchPost("/api/updateDashboardConfigurationItem", {
+			await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 				section: "Server",
 				key: "dashboard_api_key",
 				value: this.value
@@ -43,7 +43,7 @@ export default {
 			immediate: true,
 			handler(newValue){
 				if (newValue){
-					fetchGet("/api/getDashboardAPIKeys", {}, (res) => {
+					fetchGet(`${apiUrl}/getDashboardAPIKeys`, {}, (res) => {
 						console.log(res)
 						if(res.status){
 							this.apiKeys = res.data

--- a/src/static/app/src/components/settingsComponent/dashboardAPIKeysComponents/dashboardAPIKey.vue
+++ b/src/static/app/src/components/settingsComponent/dashboardAPIKeysComponents/dashboardAPIKey.vue
@@ -18,7 +18,7 @@ export default {
 	},
 	methods: {
 		deleteAPIKey(){
-			fetchPost("/api/deleteDashboardAPIKey", {
+			fetchPost(`${apiUrl}/deleteDashboardAPIKey`, {
 				Key: this.apiKey.Key
 			}, (res) => {
 				if (res.status){

--- a/src/static/app/src/components/settingsComponent/dashboardAPIKeysComponents/newDashboardAPIKey.vue
+++ b/src/static/app/src/components/settingsComponent/dashboardAPIKeysComponents/newDashboardAPIKey.vue
@@ -27,7 +27,7 @@ export default {
 	methods: {
 		submitNewAPIKey(){
 			this.submitting = true;
-			fetchPost('/api/newDashboardAPIKey', this.newKeyData, (res) => {
+			fetchPost(`${apiUrl}/newDashboardAPIKey`, this.newKeyData, (res) => {
 				if (res.status){
 					this.$emit('created', res.data);
 					this.store.newMessage("Server", "New API Key created", "success");

--- a/src/static/app/src/components/settingsComponent/dashboardSettingsInputIPAddressAndPort.vue
+++ b/src/static/app/src/components/settingsComponent/dashboardSettingsInputIPAddressAndPort.vue
@@ -35,7 +35,7 @@ export default {
 	methods:{
 		async useValidation(){
 			if(this.changed){
-				await fetchPost("/api/updateDashboardConfigurationItem", {
+				await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 					section: "Server",
 					key: this.targetData,
 					value: this.value

--- a/src/static/app/src/components/settingsComponent/dashboardSettingsInputWireguardConfigurationPath.vue
+++ b/src/static/app/src/components/settingsComponent/dashboardSettingsInputWireguardConfigurationPath.vue
@@ -33,7 +33,7 @@ export default {
 	methods:{
 		async useValidation(){
 			if(this.changed){
-				await fetchPost("/api/updateDashboardConfigurationItem", {
+				await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 					section: "Server",
 					key: this.targetData,
 					value: this.value

--- a/src/static/app/src/components/settingsComponent/dashboardTheme.vue
+++ b/src/static/app/src/components/settingsComponent/dashboardTheme.vue
@@ -10,7 +10,7 @@ export default {
 	},
 	methods: {
 		async switchTheme(value){
-			await fetchPost("/api/updateDashboardConfigurationItem", {
+			await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 				section: "Server",
 				key: "dashboard_theme",
 				value: value

--- a/src/static/app/src/components/settingsComponent/peersDefaultSettingsInput.vue
+++ b/src/static/app/src/components/settingsComponent/peersDefaultSettingsInput.vue
@@ -32,7 +32,7 @@ export default {
 	methods:{
 		async useValidation(){
 			if(this.changed){
-				await fetchPost("/api/updateDashboardConfigurationItem", {
+				await fetchPost(`${apiUrl}/updateDashboardConfigurationItem`, {
 					section: "Peers",
 					key: this.targetData,
 					value: this.value

--- a/src/static/app/src/components/setupComponent/totp.vue
+++ b/src/static/app/src/components/setupComponent/totp.vue
@@ -8,7 +8,7 @@ export default {
 	async setup(){
 		const store = DashboardConfigurationStore();
 		let l = ""
-		await fetchGet("/api/Welcome_GetTotpLink", {}, (res => {
+		await fetchGet(`${apiUrl}/Welcome_GetTotpLink`, {}, (res => {
 			if (res.status) l = res.data;
 		}));
 		return {l, store}
@@ -37,7 +37,7 @@ export default {
 			if (newVal.length === 6){
 				console.log(newVal)
 				if (/[0-9]{6}/.test(newVal)){
-					fetchPost("/api/Welcome_VerifyTotpLink", {
+					fetchPost(`{apiUrl}/Welcome_VerifyTotpLink`, {
 						totp: newVal
 					}, (res) => {
 						if (res.status){

--- a/src/static/app/src/components/signInComponents/RemoteServer.vue
+++ b/src/static/app/src/components/signInComponents/RemoteServer.vue
@@ -23,7 +23,7 @@ export default {
 				this.startTime = undefined;
 				this.endTime = undefined;
 				this.startTime = dayjs()
-				await fetch(`${this.server.host}/api/handshake`, {
+				await fetch(`${this.server.host}${apiUrl}/handshake`, {
 					headers: {
 						"content-type": "application/json",
 						"wg-dashboard-apikey": this.server.apiKey
@@ -47,7 +47,7 @@ export default {
 			}
 		},
 		async connect(){
-			await fetch(`${this.server.host}/api/authenticate`, {
+			await fetch(`${this.server.host}${apiUrl}/authenticate`, {
 				headers: {
 					"content-type": "application/json",
 					"wg-dashboard-apikey": this.server.apiKey

--- a/src/static/app/src/main.js
+++ b/src/static/app/src/main.js
@@ -11,7 +11,6 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 
-
 const app = createApp(App)
 app.use(router)
 const pinia = createPinia();

--- a/src/static/app/src/models/WireguardConfigurations.js
+++ b/src/static/app/src/models/WireguardConfigurations.js
@@ -11,7 +11,7 @@ export class WireguardConfigurations{
 	
 
 	async getConfigurations(){
-		await fetchGet("/api/getWireguardConfigurations", {}, (res) => {
+		await fetchGet(`{apiUrl}/getWireguardConfigurations`, {}, (res) => {
 			if (res.status)  this.Configurations = res.data
 		});
 	}

--- a/src/static/app/src/router/index.js
+++ b/src/static/app/src/router/index.js
@@ -17,9 +17,11 @@ import Traceroute from "@/views/traceroute.vue";
 import Totp from "@/components/setupComponent/totp.vue";
 import Share from "@/views/share.vue";
 
+const apiUrl = window.config?.apiUrl || '/api';
+
 const checkAuth = async () => {
   let result = false
-  await fetchGet("/api/validateAuthentication", {}, (res) => {
+  await fetchGet(`${apiUrl}/validateAuthentication`, {}, (res) => {
     result = res.status
   });
   return result;

--- a/src/static/app/src/stores/DashboardConfigurationStore.js
+++ b/src/static/app/src/stores/DashboardConfigurationStore.js
@@ -58,19 +58,19 @@ export const DashboardConfigurationStore = defineStore('DashboardConfigurationSt
 		},
 		
 		async getConfiguration(){
-			await fetchGet("/api/getDashboardConfiguration", {}, (res) => {
+			await fetchGet(`${apiUrl}/getDashboardConfiguration`, {}, (res) => {
 				if (res.status) this.Configuration = res.data
 			});
 		},
 		async updateConfiguration(){
-			await fetchPost("/api/updateDashboardConfiguration", {
+			await fetchPost(`${apiUrl}/updateDashboardConfiguration`, {
 				DashboardConfiguration: this.Configuration
 			}, (res) => {
 				console.log(res)
 			})
 		},
 		async signOut(){
-			await fetchGet("/api/signout", {}, (res) => {
+			await fetchGet(`${apiUrl}/signout`, {}, (res) => {
 				this.removeActiveCrossServer();
 				this.$router.go('/signin')
 			});

--- a/src/static/app/src/stores/WireguardConfigurationsStore.js
+++ b/src/static/app/src/stores/WireguardConfigurationsStore.js
@@ -67,7 +67,7 @@ export const WireguardConfigurationsStore = defineStore('WireguardConfigurations
 	}),
 	actions: {
 		async getConfigurations(){
-			await fetchGet("/api/getWireguardConfigurations", {}, (res) => {
+			await fetchGet(`${apiUrl}/getWireguardConfigurations`, {}, (res) => {
 				if (res.status)  this.Configurations = res.data
 			});
 		},

--- a/src/static/app/src/stores/wgdashboardStore.js
+++ b/src/static/app/src/stores/wgdashboardStore.js
@@ -9,7 +9,7 @@ export const wgdashboardStore = defineStore('WGDashboardStore', {
 	}),
 	actions: {
 		async getDashboardConfiguration(){
-			await fetchGet("/api/getDashboardConfiguration", {}, (res) => {
+			await fetchGet(`${apiUrl}/getDashboardConfiguration`, {}, (res) => {
 				console.log(res.status)
 				if (res.status)  this.DashboardConfiguration = res.data
 			})

--- a/src/static/app/src/views/newConfiguration.vue
+++ b/src/static/app/src/views/newConfiguration.vue
@@ -44,7 +44,7 @@ export default {
 		async saveNewConfiguration(){
 			if (this.goodToSubmit){
 				this.loading = true;
-				await fetchPost("/api/addWireguardConfiguration", this.newConfiguration, async (res) => {
+				await fetchPost(`${apiUrl}/addWireguardConfiguration`, this.newConfiguration, async (res) => {
 					if (res.status){
 						this.success = true
 						await this.store.getConfigurations()

--- a/src/static/app/src/views/ping.vue
+++ b/src/static/app/src/views/ping.vue
@@ -21,7 +21,7 @@ export default {
 		return {store}
 	},
 	mounted() {
-		fetchGet("/api/ping/getAllPeersIpAddress", {}, (res)=> {
+		fetchGet(`${apiUrl}/ping/getAllPeersIpAddress`, {}, (res)=> {
 			if (res.status){
 				this.loading = true;
 				this.cips = res.data;
@@ -34,7 +34,7 @@ export default {
 			if (this.selectedIp){
 				this.pinging = true;
 				this.pingResult = undefined
-				fetchGet("/api/ping/execute", {
+				fetchGet(`${apiUrl}/ping/execute`, {
 					ipAddress: this.selectedIp,
 					count: this.count
 				}, (res) => {

--- a/src/static/app/src/views/setup.vue
+++ b/src/static/app/src/views/setup.vue
@@ -32,7 +32,7 @@ export default {
 	methods: {
 		submit(){
 			this.loading = true
-			fetchPost("/api/Welcome_Finish", this.setup, (res) => {
+			fetchPost(`${apiUrl}/Welcome_Finish`, this.setup, (res) => {
 				if (res.status){
 					this.done = true;
 					this.$router.push('/2FASetup')

--- a/src/static/app/src/views/share.vue
+++ b/src/static/app/src/views/share.vue
@@ -14,7 +14,7 @@ export default {
 		const theme = ref("");
 		const peerConfiguration = ref("");
 		const blob = ref(new Blob())
-		await fetchGet("/api/getDashboardTheme", {}, (res) => {
+		await fetchGet(`${apiUrl}/getDashboardTheme`, {}, (res) => {
 			theme.value = res.data
 		});
 		
@@ -23,7 +23,7 @@ export default {
 			peerConfiguration.value = undefined
 			loaded.value = true;
 		}else{
-			await fetchGet("/api/sharePeer/get", {
+			await fetchGet(`${apiUrl}/sharePeer/get`, {
 				ShareID: id
 			}, (res) => {
 				if (res.status){

--- a/src/static/app/src/views/signin.vue
+++ b/src/static/app/src/views/signin.vue
@@ -12,10 +12,10 @@ export default {
 		let theme = "dark"
 		let totpEnabled = false;
 		if (!store.IsElectronApp){
-			await fetchGet("/api/getDashboardTheme", {}, (res) => {
+			await fetchGet(`${apiUrl}/getDashboardTheme`, {}, (res) => {
 				theme = res.data
 			});
-			await fetchGet("/api/isTotpEnabled", {}, (res) => {
+			await fetchGet(`${apiUrl}/isTotpEnabled`, {}, (res) => {
 				totpEnabled = res.data
 			});
 		}
@@ -41,7 +41,7 @@ export default {
 		async auth(){
 			if (this.username && this.password && ((this.totpEnabled && this.totp) || !this.totpEnabled)){
 				this.loading = true
-				await fetchPost("/api/authenticate", {
+				await fetchPost(`${apiUrl}/authenticate`, {
 					username: this.username,
 					password: this.password,
 					totp: this.totp

--- a/src/static/app/src/views/traceroute.vue
+++ b/src/static/app/src/views/traceroute.vue
@@ -20,7 +20,7 @@ export default {
 			if (this.ipAddress){
 				this.tracing = true;
 				this.tracerouteResult = undefined
-				fetchGet("/api/traceroute/execute", {
+				fetchGet(`${apiUrl}/traceroute/execute`, {
 					ipAddress: this.ipAddress,
 				}, (res) => {
 					if (res.status){

--- a/src/static/app/vite.config.js
+++ b/src/static/app/vite.config.js
@@ -7,9 +7,12 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig(({mode}) => {
   
-
+ 
   if (mode === 'electron'){
     return {
+      define: {
+        'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || '/api')
+      },
       emptyOutDir: false,
       base: './',
       plugins: [
@@ -34,7 +37,10 @@ export default defineConfig(({mode}) => {
   }
 
   return {
-    base: "/static/app/dist",
+    define: {
+      'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || '/api')
+    },
+    base: "./",
     plugins: [
       vue(),
     ],

--- a/src/static/json/manifest.json
+++ b/src/static/json/manifest.json
@@ -8,22 +8,22 @@
     "short_name": "WGDashboard",
     "icons": [
         {
-            "src": "/static/img/icon-192x192.png",
+            "src": "../img/icon-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/static/img/icon-256x256.png",
+            "src": "../img/icon-256x256.png",
             "sizes": "256x256",
             "type": "image/png"
         },
         {
-            "src": "/static/img/icon-384x384.png",
+            "src": "../img/icon-384x384.png",
             "sizes": "384x384",
             "type": "image/png"
         },
         {
-            "src": "/static/img/icon-512x512.png",
+            "src": "../img/icon-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -13,8 +13,9 @@
 	<link rel="apple-touch-icon" sizes="192x192" href="{{ url_for('static',filename='img/192x192ios.png') }}">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<link rel="icon" href="{{ url_for('static',filename='img/logo.png') }}"/>
-	<link rel="stylesheet" href="../static/app/dist/assets/index.css">
-	<script src="../static/app/dist/assets/index.js" type="module"></script>
+	<link rel="stylesheet" href="{{ url_for('static',filename='app/dist/assets/index.css') }}">
+	<script src="{{ url_for('static',filename='app/dist/assets/index.js') }}" type="module"></script>
+	<script src="{{ url_for('static',filename='app/public/config.js') }}"></script>
 </head>
 <body>
 	<div id="app" class="w-100 vh-100"></div>

--- a/src/wgd.sh
+++ b/src/wgd.sh
@@ -7,6 +7,11 @@ app_official_name="WGDashboard"
 venv_python="./venv/bin/python3"
 venv_gunicorn="./venv/bin/gunicorn"
 
+# Check if URL_PREFIX is not set or is empty
+if [[ $URL_PREFIX ]]; then
+  script_name="--env SCRIPT_NAME=${URL_PREFIX}"
+fi
+
 PID_FILE=./gunicorn.pid
 environment=$(if [[ $ENVIRONMENT ]]; then echo $ENVIRONMENT; else echo 'develop'; fi)
 if [[ $CONFIGURATION_PATH ]]; then
@@ -240,7 +245,7 @@ gunicorn_start () {
     export PATH=$PATH:/usr/local/bin:$HOME/.local/bin
   fi
   _check_and_set_venv
-  sudo "$venv_gunicorn" --config ./gunicorn.conf.py
+  sudo "$venv_gunicorn" --config ./gunicorn.conf.py ${script_name}
   sleep 5
   checkPIDExist=0
   while [ $checkPIDExist -eq 0 ]


### PR DESCRIPTION
Hi @donaldzou 

I'm looking for way to configure this app with reverse proxy and use it wit some configurable url prefix like
http://localhost:10086/url_prefix

I am not good enough at VueJS but can you check this pull request and see if it is possible or acceptable for you to add such functionality

1. The python is easily configured by using
```
sudo "$venv_gunicorn" --config ./gunicorn.conf.py --env SCRIPT_NAME=${URL_PREFIX}
```
2. But front-end needs prefix like variable and not absolute path for some resources

So please look at this, and maybe it will be possible to implement this. This is a very common and useful feature that allows use application on some common host but with custom URL prefix.

PS: I tested this variant - it's works, but the code maybe done not in proper way. 