### PR TITLE
Adding HTTPS Support

### DIFF
--- a/src/gunicorn.conf.py
+++ b/src/gunicorn.conf.py
@@ -32,8 +32,8 @@ if os.path.exists("./ssl.ini"):
             certfile = cert
             keyfile = pem
             print(f"[Gunicorn][HTTPS] Found certificate and private key file", flush=True)
-            print(f"[Gunicorn][HTTPS] Certificate: ${certfile}", flush=True)
-            print(f"[Gunicorn][HTTPS] Private Key: ${keyfile}", flush=True)
+            print(f"[Gunicorn][HTTPS] Certificate: {certfile}", flush=True)
+            print(f"[Gunicorn][HTTPS] Private Key: {keyfile}", flush=True)
        
 
 print(f"[Gunicorn] WGDashboard w/ Gunicorn will be running on {bind}", flush=True)

--- a/src/gunicorn.conf.py
+++ b/src/gunicorn.conf.py
@@ -31,9 +31,11 @@ if os.path.exists("./ssl.ini"):
         if cert and pem and len(cert) > 0 and len(pem) > 0:
             certfile = cert
             keyfile = pem
-            print(f"[WGDashboard] HTTPS enable", flush=True)
+            print(f"[Gunicorn][HTTPS] Found certificate and private key file", flush=True)
+            print(f"[Gunicorn][HTTPS] Certificate: ${certfile}", flush=True)
+            print(f"[Gunicorn][HTTPS] Private Key: ${keyfile}", flush=True)
        
 
-print(f"[WGDashboard] WGDashboard w/ Gunicorn will be running on {bind}", flush=True)
-print(f"[WGDashboard] Access log file is at {accesslog}", flush=True)
-print(f"[WGDashboard] Error log file is at {errorlog}", flush=True)
+print(f"[Gunicorn] WGDashboard w/ Gunicorn will be running on {bind}", flush=True)
+print(f"[Gunicorn] Access log file is at {accesslog}", flush=True)
+print(f"[Gunicorn] Error log file is at {errorlog}", flush=True)

--- a/src/gunicorn.conf.py
+++ b/src/gunicorn.conf.py
@@ -1,14 +1,14 @@
-import dashboard
+import os.path
+
+import dashboard, configparser
 from datetime import datetime
 
 global sqldb, cursor, DashboardConfig, WireguardConfigurations, AllPeerJobs, JobLogger
 app_host, app_port = dashboard.gunicornConfig()
 date = datetime.today().strftime('%Y_%m_%d_%H_%M_%S')
 
-
 def post_worker_init(worker):
     dashboard.startThreads()
-
 
 worker_class = 'gthread'
 workers = 1
@@ -21,6 +21,19 @@ accesslog = f"./log/access_{date}.log"
 log_level = "debug"
 capture_output = True
 errorlog = f"./log/error_{date}.log"
+
+if os.path.exists("./ssl.ini"):
+    sslConfig = configparser.ConfigParser()
+    sslConfig.read_file(open('./ssl.ini', 'r'))
+    if sslConfig.has_section('SSL'):
+        cert = sslConfig.get('SSL', 'certificate_path')
+        pem = sslConfig.get('SSL', 'private_key_path')
+        if cert and pem and len(cert) > 0 and len(pem) > 0:
+            certfile = cert
+            keyfile = pem
+            print(f"[WGDashboard] HTTPS enable", flush=True)
+       
+
 print(f"[WGDashboard] WGDashboard w/ Gunicorn will be running on {bind}", flush=True)
 print(f"[WGDashboard] Access log file is at {accesslog}", flush=True)
 print(f"[WGDashboard] Error log file is at {errorlog}", flush=True)


### PR DESCRIPTION
- This new workflow would enable user to use HTTPS with WGDashboard

**Steps to enable**

1. Clone this branch
2. Install WGDashboard with `./wgd.sh install`
3. You'll see a new file created called `ssl.ini`
4. Open it with your favourite editor
5. Paste the absolute path of your certificate and private key into the file and save, for example: 
```
[SSL]
certificate_path = /etc/letsencrypt/live/toronto.server.donaldzou.home/fullchain.pem
private_key_path = /etc/letsencrypt/live/toronto.server.donaldzou.home/privkey.pem
``` 
> If you created your cert with `certbot`, you can find your path with `certbot certificates`
6. Start WGDashboard with `./wgd.sh start`
7. If everything went well, you will see the following output:
```
...
[Gunicorn][HTTPS] Found certificate and private key file
[Gunicorn][HTTPS] Certificate: /etc/letsencrypt/live/toronto.server.donaldzou.home/fullchain.pem
[Gunicorn][HTTPS] Private Key: /etc/letsencrypt/live/toronto.server.donaldzou.home/privkey.pem
...
[WGDashboard] WGDashboard w/ Gunicorn started successfully
```
8. Try access WGDashboard with `https://` and see if it works