### PR TITLE
[Enhancement] Supporting "table" directive in the configuration

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -945,7 +945,8 @@ class WireguardConfiguration:
             },
             "ConnectedPeers": len(list(filter(lambda x: x.status == "running", self.Peers))),
             "TotalPeers": len(self.Peers),
-            "Protocol": self.Protocol
+            "Protocol": self.Protocol,
+            "Table": self.Table,
         }
     
     def backupConfigurationFile(self) -> tuple[bool, dict[str, str]]:
@@ -1047,7 +1048,7 @@ class WireguardConfiguration:
         dataChanged = False
         with open(self.configPath, 'r') as f:
             original = [l.rstrip("\n") for l in f.readlines()]
-            allowEdit = ["Address", "PreUp", "PostUp", "PreDown", "PostDown", "ListenPort"]
+            allowEdit = ["Address", "PreUp", "PostUp", "PreDown", "PostDown", "ListenPort", "Table"]
             if self.Protocol == 'awg':
                 allowEdit += ["Jc", "Jmin", "Jmax", "S1", "S2", "H1", "H2", "H3", "H4"]
             start = original.index("[Interface]")

--- a/src/static/app/src/components/configurationComponents/editConfiguration.vue
+++ b/src/static/app/src/components/configurationComponents/editConfiguration.vue
@@ -171,6 +171,17 @@ const deleteConfigurationModal = ref(false)
 									       id="configuration_listen_port">
 
 								</div>
+								<div>
+									<label for="configuration_table" class="form-label">
+										<small class="text-muted">
+											<LocaleText t="Table"></LocaleText>
+										</small>
+									</label>
+									<input type="text" class="form-control form-control-sm rounded-3"
+									       :disabled="saving"
+									       v-model="data.Table"
+									       id="configuration_table">
+								</div>
 								<div v-for="key in ['PreUp', 'PreDown', 'PostUp', 'PostDown']">
 									<label :for="'configuration_' + key" class="form-label">
 										<small class="text-muted">

--- a/src/static/app/src/views/newConfiguration.vue
+++ b/src/static/app/src/views/newConfiguration.vue
@@ -34,6 +34,7 @@ export default {
 				PreDown: "",
 				PostUp: "",
 				PostDown: "",
+				Table: "",
 				Protocol: "wg",
 				Jc: 5,
 				Jmin: 49,
@@ -339,6 +340,19 @@ export default {
 								IP Address/CIDR is invalid
 							</div>
 							
+						</div>
+					</div>
+				</div>
+				<div class="card rounded-3 shadow">
+					<div class="card-header">
+						<LocaleText t="Table"></LocaleText>
+					</div>
+					<div class="card-body">
+						<input type="text" class="form-control" placeholder="Ex: off" id="Table" 
+						       v-model="this.newConfiguration.Table"
+						       :disabled="this.loading">
+						<div class="invalid-feedback">
+							<div v-if="this.error">{{this.errorMessage}}</div>
 						</div>
 					</div>
 				</div>

--- a/src/static/locale/language_template.json
+++ b/src/static/locale/language_template.json
@@ -59,6 +59,7 @@
 	"Turning Off\\.\\.\\.": "",
 	"Address": "",
 	"Listen Port": "",
+	"Table": "",
 	"Public Key": "",
 	"Connected Peers": "",
 	"Total Usage": "",


### PR DESCRIPTION
This pull request introduces the addition of a new configuration field, `Table`, across the backend and frontend of the application. The changes ensure that the `Table` field is supported in the configuration settings, user interface, and localization files.

### Backend Changes:
* Added support for the `Table` field in the JSON representation of configurations by modifying the `toJson` method in `src/dashboard.py`.
* Updated the list of editable configuration fields in the `updateConfigurationSettings` method to include `Table`.

### Frontend Changes:
* Added an input field for `Table` in the `editConfiguration` component (`src/static/app/src/components/configurationComponents/editConfiguration.vue`).
* Included the `Table` field in the default configuration object and added a corresponding input card in the `newConfiguration` view (`src/static/app/src/views/newConfiguration.vue`). [[1]](diffhunk://#diff-22f9ce23b9299f9cc67f77918d3a894009ed1f363dfcd30346188689e8b943ebR37) [[2]](diffhunk://#diff-22f9ce23b9299f9cc67f77918d3a894009ed1f363dfcd30346188689e8b943ebR346-R358)

### Localization:
* Added a new localization key for `Table` in the `language_template.json` file to support translations.