### PR TITLE
API Peer delete bug #712 fix: fixed issue with delete endpoint return…

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -804,6 +804,9 @@ class WireguardConfiguration:
             return ResponseObject(False, "Failed to save configuration through WireGuard")
 
         self.getPeers()
+        
+        if numOfDeletedPeers == 0 and numOfFailedToDeletePeers == 0:
+            return ResponseObject(False, "No peer(s) to delete found", responseCode=404)
 
         if numOfDeletedPeers == len(listOfPublicKeys):
             return ResponseObject(True, f"Deleted {numOfDeletedPeers} peer(s)")
@@ -2464,11 +2467,11 @@ def API_deletePeers(configName: str) -> ResponseObject:
     peers = data['peers']
     if configName in WireguardConfigurations.keys():
         if len(peers) == 0:
-            return ResponseObject(False, "Please specify one or more peers")
+            return ResponseObject(False, "Please specify one or more peers", status_code=400)
         configuration = WireguardConfigurations.get(configName)
         return configuration.deletePeers(peers)
 
-    return ResponseObject(False, "Configuration does not exist")
+    return ResponseObject(False, "Configuration does not exist", status_code=404)
 
 @app.post(f'{APP_PREFIX}/api/restrictPeers/<configName>')
 def API_restrictPeers(configName: str) -> ResponseObject:


### PR DESCRIPTION
This pull request makes improvements to error handling in the `deletePeers` functionality within the `src/dashboard.py` file. The changes enhance the clarity and accuracy of the responses by adding HTTP status codes and refining return messages.

### Error handling improvements:

* `src/dashboard.py` (`deletePeers`): Added a check to return a 404 response when no peers are found to delete, ensuring the user receives accurate feedback when no action is taken.

* `src/dashboard.py` (`API_deletePeers`): 
  - Updated the response when no peers are specified to include a 400 status code, clarifying that the request is invalid.
  - Modified the response for non-existent configurations to include a 404 status code, aligning with standard HTTP response conventions.