### PR TITLE
Fix for #783: Adding peer fails if default MTU or Keepalive isn't set

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -2570,9 +2570,9 @@ def API_addPeers(configName):
             allowed_ips_validation: bool = data.get('allowed_ips_validation', True)
             
             endpoint_allowed_ip: str = data.get('endpoint_allowed_ip', "")
-            dns_addresses: str = data.get('DNS', "")
-            mtu: int = data.get('mtu', 0)
-            keep_alive: int = data.get('keepalive', 0)
+            dns_addresses: str = data.get('DNS', "") or ""
+            mtu: int = data.get('mtu', 0) or 0
+            keep_alive: int = data.get('keepalive', 0) or 0
             preshared_key: str = data.get('preshared_key', "")            
 
             if mtu < 0 or mtu > 1460:

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -2569,16 +2569,17 @@ def API_addPeers(configName):
             allowed_ips: list[str] = data.get('allowed_ips', [])
             allowed_ips_validation: bool = data.get('allowed_ips_validation', True)
             
-            endpoint_allowed_ip: str = data.get('endpoint_allowed_ip', DashboardConfig.GetConfig("Peers", "peer_endpoint_allowed_ip")[1])
-            dns_addresses: str = data.get('DNS', DashboardConfig.GetConfig("Peers", "peer_global_DNS")[1])
-            mtu: int = data.get('mtu', int(DashboardConfig.GetConfig("Peers", "peer_MTU")[1]))
-            keep_alive: int = data.get('keepalive', int(DashboardConfig.GetConfig("Peers", "peer_keep_alive")[1]))
+            endpoint_allowed_ip: str = data.get('endpoint_allowed_ip', "")
+            dns_addresses: str = data.get('DNS', "")
+            mtu: int = data.get('mtu', 0)
+            keep_alive: int = data.get('keepalive', 0)
             preshared_key: str = data.get('preshared_key', "")            
-    
-            if type(mtu) is not int or mtu < 0 or mtu > 1460:
-                mtu = int(DashboardConfig.GetConfig("Peers", "peer_MTU")[1])
-            if type(keep_alive) is not int or keep_alive < 0:
-                keep_alive = int(DashboardConfig.GetConfig("Peers", "peer_keep_alive")[1])
+
+            if mtu < 0 or mtu > 1460:
+                return ResponseObject(False, "MTU must be between 0 and 1460")
+            if keep_alive < 0 or keep_alive > 65535:
+                return ResponseObject(False, "Persistent Keepalive must be between 0 and 65535")
+                
             config = WireguardConfigurations.get(configName)
             if not config.getStatus():
                 config.toggleConfiguration()


### PR DESCRIPTION
Proposed fix for #783 

There are several ways to fix this issue, and this is just one way, but I think this is the most appropriate solution from a user experience perspective.

---

When adding peers, **the default peer settings should not be used at all, even if no settings are provided.** The web GUI already auto populates the fields with the set defaults, and that is really all that is needed. For example, if the Keepalive field is auto populated with ```25```, and I manually remove the ```25``` before adding the peer, I expect the resulting peer configuration to behave as if ```PersistentKeepalive``` isn't present at all (i.e. disabled). I do *not* expect the dashboard to quietly add the default value back in after I manually deleted it. Ditto for invalid settings; don't quietly add them back, tell me what's wrong.

---

For both ```MTU``` and ```PersistentKeepalive```, this commit changes the default to ```0```, which disables the feature. This is the same as omitting these setting from the configuration file entirely, which is valid and typical for Wireguard.

For ```DNS```, it's the same as above, except it's an empty string.

For ```AllowedIPs```, this commit changes the default to an empty string. Omitting ```AllowedIPs``` from a Wireguard configuration isn't very typical, but it is technically valid. That being said, the dashboard currently requires setting "Endpoint Allowed IPs" when adding a peer, so it's a bit of a moot point.

I removed the type checking for ```mtu``` and ```keep_alive``` since their types are defined 4 lines earlier. I added an upper bound of 65535 for ```keep_alive```, which was the maximum that my Wireguard would let me set it. FWIW, my Wireguard let me set the MTU between 576 and 65535.