### PR TITLE
chore: update documentation links in agentModal and helpModal

### DIFF
--- a/src/static/app/src/components/navbarComponents/agentModal.vue
+++ b/src/static/app/src/components/navbarComponents/agentModal.vue
@@ -29,7 +29,7 @@ const store = DashboardConfigurationStore()
 					<LocaleText t="You can visit our: "></LocaleText>
 				</p>
 				<div class="list-group">
-					<a href="https://donaldzou.github.io/WGDashboard-Documentation/"
+					<a href="https://docs.wgdashboard.dev/"
 					   target="_blank" class="list-group-item list-group-item-action d-flex align-items-center">
 						<i class="bi bi-book-fill"></i>
 						<LocaleText class="ms-auto" t="Official Documentation"></LocaleText>

--- a/src/static/app/src/components/navbarComponents/helpModal.vue
+++ b/src/static/app/src/components/navbarComponents/helpModal.vue
@@ -52,7 +52,7 @@ onMounted(() => {
 								</div>
 							</div>
 						</a>
-						<a class="card text-decoration-none" href="https://donaldzou.github.io/WGDashboard-Documentation/" target="_blank">
+						<a class="card text-decoration-none" href="https://docs.wgdashboard.dev/" target="_blank">
 							<div class="card-body d-flex gap-4 align-items-center">
 								<h1 class="mb-0">
 									<i class="bi bi-hash"></i>


### PR DESCRIPTION
# Problem

https://github.com/user-attachments/assets/224124f3-d799-4024-a58f-06dfc62f7fab

### 🔧 What was changed

Updated outdated documentation URLs in the following components:

- `agentModal`
- `helpModal`

### 📝 Details

Replaced:

https://donaldzou.github.io/WGDashboard-Documentation/

with:

https://docs.wgdashboard.dev/

### 📌 Why

To ensure users are directed to the current and maintained version of the WGDashboard documentation.

### ✅ Impact

No changes to functionality or UI behavior — only updated static links.
