### PR TITLE
Fix: Test email failure

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1310,6 +1310,7 @@ def API_Email_Send():
     if "Receiver" not in data.keys() or "Subject" not in data.keys():
         return ResponseObject(False, "Please at least specify receiver and subject")
     body = data.get('Body', '')
+    subject = data.get('Subject','')
     download = None
     if ("ConfigurationName" in data.keys() 
             and "Peer" in data.keys()):


### PR DESCRIPTION
When attempting to send a test email, the system fails for subject not being set. It appears that Subject was moved to a variable but does not get a default value at the beginning. Adding this variable and pulling it from the data object, fixes this.