### PR TITLE
fix: set date when null expiredate for peersharelink

### DIFF
--- a/src/modules/PeerShareLink.py
+++ b/src/modules/PeerShareLink.py
@@ -9,6 +9,8 @@ class PeerShareLink:
         self.Configuration = Configuration
         self.SharedDate = SharedDate
         self.ExpireDate = ExpireDate
+        if not self.ExpireDate:
+            self.ExpireDate = datetime.strptime("2199-12-31","%Y-%m-%d")
 
     def toJson(self):
         return {


### PR DESCRIPTION
Fix to set the expire date field when null by setting it to a date in the future. 

This should only be a compatibility fix when coming from previous versions where the ExpireDate was not set.

Addresses: [875](https://github.com/donaldzou/WGDashboard/issues/875)