### PR TITLE
fix: Adds psycopg dependency in order to run properly

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,6 @@ requests==2.32.5
 tcconfig==0.30.1
 sqlalchemy==2.0.44
 sqlalchemy_utils==0.42.0
-psycopg==3.2.12
 psycopg[binary]==3.2.12
 PyMySQL==1.1.2
 tzlocal==5.3.1


### PR DESCRIPTION
## Issue

Currently, when attempting to run the WGDashboard via the docker container created by @DaanSelen , with a configuration targeting `PostgreSQL` external database, the following is observed. Mainly, the psycopg library attempts ot import a pq wrapper. None are found and therefore an exception is thrown on app startup.

```
WGDashboard] Starting WGDashboard with Gunicorn in the background.
--- Logging error ---
Traceback (most recent call last):
  File "/opt/wgdashboard/src/modules/ConnectionString.py", line 19, in ConnectionString
    if not database_exists(cn):
           ~~~~~~~~~~~~~~~^^^^
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/sqlalchemy_utils/functions/database.py", line 475, in database_exists
    engine = sa.create_engine(url, isolation_level='AUTOCOMMIT')
  File "<string>", line 2, in create_engine
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/sqlalchemy/util/deprecations.py", line 281, in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/sqlalchemy/engine/create.py", line 617, in create_engine
    dbapi = dbapi_meth(**dbapi_args)
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/sqlalchemy/dialects/postgresql/psycopg.py", line 418, in import_dbapi
    import psycopg
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/psycopg/__init__.py", line 9, in <module>
    from . import pq  # noqa: F401 import early to stabilize side effects
    ^^^^^^^^^^^^^^^^
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/psycopg/pq/__init__.py", line 116, in <module>
    import_from_libpq()
    ~~~~~~~~~~~~~~~~~^^
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/psycopg/pq/__init__.py", line 108, in import_from_libpq
            raise ImportError(
    ...<4 lines>...
            )
**ImportError: no pq wrapper available.
Attempts made:
- couldn't import psycopg 'c' implementation: No module named 'psycopg_c'
- couldn't import psycopg 'binary' implementation: No module named 'psycopg_binary'
- couldn't import psycopg 'python' implementation: libpq library not found**

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1151, in emit
    msg = self.format(record)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/logging/__init__.py", line 712, in format
    record.message = record.getMessage()
                     ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/logging/__init__.py", line 400, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/opt/wgdashboard/src/./venv/bin/gunicorn", line 7, in <module>
    sys.exit(run())
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/gunicorn/app/wsgiapp.py", line 66, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]", prog=prog).run()
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/gunicorn/app/base.py", line 27, in __init__
    self.do_load_config()
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/gunicorn/app/base.py", line 35, in do_load_config
    self.load_config()
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/gunicorn/app/wsgiapp.py", line 38, in load_config
    super().load_config()
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/gunicorn/app/base.py", line 173, in load_config
    self.load_config_from_file(args.config)
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/gunicorn/app/base.py", line 152, in load_config_from_file
    return self.load_config_from_module_name_or_filename(location=filename)
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/gunicorn/app/base.py", line 136, in load_config_from_module_name_or_filename
    cfg = self.get_config_from_filename(filename)
  File "/opt/wgdashboard/src/venv/lib/python3.13/site-packages/gunicorn/app/base.py", line 110, in get_config_from_filename
    spec.loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/wgdashboard/src/gunicorn.conf.py", line 1, in <module>
    import dashboard
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/wgdashboard/src/dashboard.py", line 194, in <module>
    DashboardConfig = DashboardConfig()
  File "/opt/wgdashboard/src/modules/DashboardConfig.py", line 98, in __init__
    self.engine = db.create_engine(ConnectionString('wgdashboard'))
  File "/opt/wgdashboard/src/modules/ConnectionString.py", line 22, in ConnectionString
    current_app.logger.error("Database error. Terminating...", e)
Message: 'Database error. Terminating...'
Arguments: (ImportError("no pq wrapper available.\nAttempts made:\n- couldn't import psycopg 'c' implementation: No module named 'psycopg_c'\n- couldn't import psycopg 'binary' implementation: No module named 'psycopg_binary'\n- couldn't import psycopg 'python' implementation: libpq library not found"),)
```


## Changes

- Adds a matching package `psycopg[binary]` to requirements.txt to ensure needed dependencies are present when the application initializes