### PR TITLE
fix: domainnx error logoout

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1342,12 +1342,17 @@ def API_traceroute_execute():
                                   data=json.dumps([x['ip'] for x in result]))
                 d = r.json()
                 for i in range(len(result)):
-                    result[i]['geo'] = d[i]  
+                    result[i]['geo'] = d[i]
+
+                return ResponseObject(data=result)
+
             except Exception as e:
+                app.logger.error(f"Failed to gather the geolocation data: {e}")
                 return ResponseObject(data=result, message="Failed to request IP address geolocation")
-            return ResponseObject(data=result)
-        except Exception as exp:
-            return ResponseObject(False, exp)
+    
+        except Exception as e:
+            app.logger.error(f"Failed to execute the traceroute: {e}")
+            return ResponseObject(data=[], message="Failed to traceroute the given parameter")
     else:
         return ResponseObject(False, "Please provide ipAddress")
 


### PR DESCRIPTION
When the dashboard is unable to resolve the given name in a traceroute (for example with a faulty DNS system) it handles it more gracefully.

fix: https://github.com/WGDashboard/WGDashboard/issues/1059

It logs the error to the logs instead of throwing a traceback and logging the user out.