### PR TITLE
Updated resolvconf call in entrypoint.sh to fix dns inside container

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -220,7 +220,9 @@ start_and_monitor() {
 
   ${WGDASH}/src/venv/bin/gunicorn --config ${WGDASH}/src/gunicorn.conf.py
 
+  cp /etc/resolv.conf /etc/resolv.conf.docker
   /usr/sbin/resolvconf -u
+  cat /etc/resolv.conf.docker | resolvconf -a docker.inet
 
   if [ $? -ne 0 ]; then
     echo "Loading WGDashboard failed... Look above for details."


### PR DESCRIPTION
Hello! Dns inside container doesn't work after start because /etc/resolv.conf  is empty. Fixed by removing the resolvconf call.

My docker version is 28.4.0.