### PR TITLE
Avoid false rollover from float drift

### DIFF
--- a/src/modules/WireguardConfiguration.py
+++ b/src/modules/WireguardConfiguration.py
@@ -791,7 +791,11 @@ class WireguardConfiguration:
                         cur_total_receive = float(data_usage[i][1]) / (1024 ** 3)
                         cumulative_receive = cur_i['cumu_receive'] + total_receive
                         cumulative_sent = cur_i['cumu_sent'] + total_sent
-                        if total_sent <= cur_total_sent and total_receive <= cur_total_receive:
+                        # Allow minor floating-point drift to avoid false rollover.
+                        epsilon_gb = 0.0005  # ~0.5 MB
+                        sent_diff = cur_total_sent - total_sent
+                        recv_diff = cur_total_receive - total_receive
+                        if sent_diff >= -epsilon_gb and recv_diff >= -epsilon_gb:
                             total_sent = cur_total_sent
                             total_receive = cur_total_receive
                         else:


### PR DESCRIPTION
## Summary\n- Add a small tolerance when comparing WireGuard byte counters to avoid treating tiny float drift as a rollover.\n- Prevents cumulative totals from exploding when peers are idle.\n\n## Details\nWGDashboard stores counters in GB as floats. Due to rounding, the current value can be slightly smaller than the previous sample, which previously triggered the rollover path and added totals to cumulative on each refresh. This change adds a ~0.5MB tolerance to treat tiny drift as non-rollover.\n\n## Testing\n- Observed stable totals after repeated refreshes with no traffic.\n\n