### PR TITLE
Harden Amnezia DataUsage totals for NULL/string values

### DIFF
--- a/src/modules/AmneziaWireguardConfiguration.py
+++ b/src/modules/AmneziaWireguardConfiguration.py
@@ -11,21 +11,21 @@ from .WireguardConfiguration import WireguardConfiguration
 from .DashboardWebHooks import DashboardWebHooks
 
 
-def _safe_int(value) -> int:
+def _safe_float(value) -> float:
     try:
         if value is None:
-            return 0
+            return 0.0
         if isinstance(value, bool):
-            return int(value)
+            return float(value)
         if isinstance(value, (int, float)):
-            return int(value)
+            return float(value)
         if isinstance(value, str):
             if value.strip() == "":
-                return 0
-            return int(float(value))
-        return int(value)
+                return 0.0
+            return float(value)
+        return float(value)
     except Exception:
-        return 0
+        return 0.0
 
 
 class AmneziaWireguardConfiguration(WireguardConfiguration):
@@ -49,11 +49,11 @@ class AmneziaWireguardConfiguration(WireguardConfiguration):
     def toJson(self):
         self.Status = self.getStatus()
         def peer_total(peer):
-            return _safe_int(peer.cumu_data) + _safe_int(peer.total_data)
+            return _safe_float(peer.cumu_data) + _safe_float(peer.total_data)
         def peer_sent(peer):
-            return _safe_int(peer.cumu_sent) + _safe_int(peer.total_sent)
+            return _safe_float(peer.cumu_sent) + _safe_float(peer.total_sent)
         def peer_receive(peer):
-            return _safe_int(peer.cumu_receive) + _safe_int(peer.total_receive)
+            return _safe_float(peer.cumu_receive) + _safe_float(peer.total_receive)
         return {
             "Status": self.Status,
             "Name": self.Name,


### PR DESCRIPTION
## Summary
Follow-up to #1106: AmneziaWireguardConfiguration overrides `toJson()` and had the same unsafe `cumu_* + total_*` addition, which can raise `TypeError: NoneType + str` when older/copied DBs contain NULLs or text.

## What changed
- Adds a small null/type-safe conversion helper local to AmneziaWireguardConfiguration.
- Uses it for `DataUsage` totals in `toJson()`.

## Why this fixes it
The Amnezia override now safely handles NULLs and numeric strings, preventing the same crash in AWG configs.

Fixes: WGDashboard/WGDashboard#1077 (Amnezia override)
Refs: #1106
