### PR TITLE
Harden client assignment totals for NULL/string values

### DIFF
--- a/src/modules/DashboardClientsPeerAssignment.py
+++ b/src/modules/DashboardClientsPeerAssignment.py
@@ -6,21 +6,21 @@ from .DashboardLogger import DashboardLogger
 import sqlalchemy as db
 from .WireguardConfiguration import WireguardConfiguration
 
-def _safe_int(value) -> int:
+def _safe_float(value) -> float:
     try:
         if value is None:
-            return 0
+            return 0.0
         if isinstance(value, bool):
-            return int(value)
+            return float(value)
         if isinstance(value, (int, float)):
-            return int(value)
+            return float(value)
         if isinstance(value, str):
             if value.strip() == "":
-                return 0
-            return int(float(value))
-        return int(value)
+                return 0.0
+            return float(value)
+        return float(value)
     except Exception:
-        return 0
+        return 0.0
 
 class Assignment:
     def __init__(self, **kwargs):
@@ -162,9 +162,9 @@ class DashboardClientsPeerAssignment:
                     'id': p.id,
                     'private_key': p.private_key,
                     'name': p.name,
-                    'received_data': _safe_int(p.total_receive) + _safe_int(p.cumu_receive),
-                    'sent_data': _safe_int(p.total_sent) + _safe_int(p.cumu_sent),
-                    'data': _safe_int(p.total_data) + _safe_int(p.cumu_data),
+                    'received_data': _safe_float(p.total_receive) + _safe_float(p.cumu_receive),
+                    'sent_data': _safe_float(p.total_sent) + _safe_float(p.cumu_sent),
+                    'data': _safe_float(p.total_data) + _safe_float(p.cumu_data),
                     'status': p.status,
                     'latest_handshake': p.latest_handshake,
                     'allowed_ip': p.allowed_ip,


### PR DESCRIPTION
## Summary
Follow-up to #1106: `DashboardClientsPeerAssignment.GetAssignedPeers()` performs the same unsafe `total_* + cumu_*` addition, which can raise `TypeError` if older/copied DBs contain NULLs or numeric strings.

## What changed
- Adds a small null/type-safe conversion helper local to DashboardClientsPeerAssignment.
- Uses it for `received_data`, `sent_data`, and `data` totals.

## Why this fixes it
The client assignment API no longer crashes on NULL or string counters and returns consistent totals.

Fixes: WGDashboard/WGDashboard#1077 (client assignment totals)
Refs: #1106
