### PR TITLE
Add aria labels to peer configuration controls

### DIFF
--- a/src/static/app/src/components/configurationComponents/configurationBackupRestore.vue
+++ b/src/static/app/src/components/configurationComponents/configurationBackupRestore.vue
@@ -45,7 +45,7 @@ const createBackup = () => {
 						<h4 class="mb-0">
 							<LocaleText t="Backup & Restore"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="$emit('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="$emit('close')" aria-label="Close"></button>
 					</div>
 					<button 
 						@click="createBackup()"

--- a/src/static/app/src/components/configurationComponents/deleteConfiguration.vue
+++ b/src/static/app/src/components/configurationComponents/deleteConfiguration.vue
@@ -54,7 +54,7 @@ const emits = defineEmits(["backup", "close"])
 						<h5 class="mb-0">
 							<LocaleText t="Are you sure to delete this configuration?"></LocaleText>
 						</h5>
-						<button type="button" class="btn-close ms-auto" @click="emits('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="emits('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4 text-muted">
 						<p class="mb-0">

--- a/src/static/app/src/components/configurationComponents/editConfiguration.vue
+++ b/src/static/app/src/components/configurationComponents/editConfiguration.vue
@@ -97,7 +97,7 @@ const deleteConfigurationModal = ref(false)
 							<h4 class="mb-0">
 								<LocaleText t="Configuration Settings"></LocaleText>
 							</h4>
-							<button type="button" class="btn-close ms-auto" @click="$emit('close')"></button>
+							<button type="button" class="btn-close ms-auto" @click="$emit('close')" aria-label="Close"></button>
 						</div>
 						<div class="card-body px-4 pb-4">
 							<div class="d-flex gap-2 flex-column">

--- a/src/static/app/src/components/configurationComponents/editConfigurationComponents/editRawConfigurationFile.vue
+++ b/src/static/app/src/components/configurationComponents/editConfigurationComponents/editRawConfigurationFile.vue
@@ -53,7 +53,7 @@ const saveRaw = async () => {
 						<h5 class="mb-0">
 							<LocaleText t="Edit Raw Configuration File"></LocaleText>
 						</h5>
-						<button type="button" class="btn-close ms-auto" @click="emits('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="emits('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4 d-flex flex-column gap-3">
 						<div class="alert alert-danger rounded-3 mb-0" v-if="error">

--- a/src/static/app/src/components/configurationComponents/peer.vue
+++ b/src/static/app/src/components/configurationComponents/peer.vue
@@ -111,8 +111,9 @@ export default {
 					     :class="{active: this.subMenuOpened}"
 					>
 						<a role="button" class="text-body"
+						   aria-label="Peer actions"
 						   @click="this.subMenuOpened = true">
-							<h5 class="mb-0"><i class="bi bi-three-dots"></i></h5>
+							<h5 class="mb-0"><i class="bi bi-three-dots" aria-hidden="true"></i></h5>
 						</a>
 						<Transition name="slide-fade">
 							<PeerSettingsDropdown
@@ -137,7 +138,7 @@ export default {
 		<div class="card-footer" role="button" @click="$emit('details')">
 			<small class="d-flex align-items-center">
 				<LocaleText t="Details"></LocaleText>
-				<i class="bi bi-chevron-right ms-auto"></i>
+				<i class="bi bi-chevron-right ms-auto" aria-hidden="true"></i>
 			</small>
 		</div>
 	</div>

--- a/src/static/app/src/components/configurationComponents/peerAddModal.vue
+++ b/src/static/app/src/components/configurationComponents/peerAddModal.vue
@@ -97,7 +97,7 @@ watch(() => {
 						<h4 class="mb-0">
 							<LocaleText t="Add Peers"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="emits('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="emits('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4 pb-4">
 						<div class="d-flex flex-column gap-2">

--- a/src/static/app/src/components/configurationComponents/peerAssignModal.vue
+++ b/src/static/app/src/components/configurationComponents/peerAssignModal.vue
@@ -33,7 +33,7 @@ const assignClient = async (clientID) => {
 						<h4 class="mb-0">
 							<LocaleText t="Assign Peer to Client"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="emits('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="emits('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4 pb-4 d-flex gap-2 flex-column">
 						<AssignedClients

--- a/src/static/app/src/components/configurationComponents/peerConfigurationFile.vue
+++ b/src/static/app/src/components/configurationComponents/peerConfigurationFile.vue
@@ -68,7 +68,7 @@ const copy = async () => {
 							<LocaleText t="Peer Configuration File"></LocaleText>
 						</h4>
 						<button type="button" class="btn-close ms-auto" 
-						        @click="emit('close')"></button>
+						        @click="emit('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body p-4 d-flex flex-column gap-3">
 						<div style="height: 300px" class="d-flex">

--- a/src/static/app/src/components/configurationComponents/peerDetailsModal.vue
+++ b/src/static/app/src/components/configurationComponents/peerDetailsModal.vue
@@ -46,7 +46,7 @@ defineEmits(['close'])
 						<h4 class="mb-0 fw-normal">
 							<LocaleText t="Peer Details"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="$emit('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="$emit('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4">
 						<div>

--- a/src/static/app/src/components/configurationComponents/peerJobs.vue
+++ b/src/static/app/src/components/configurationComponents/peerJobs.vue
@@ -55,7 +55,7 @@ export default {
 						<h4 class="mb-0 fw-normal">
 							<LocaleText t="Schedule Jobs"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4 pb-4 pt-2 position-relative">
 						<div class="d-flex align-items-center mb-3">

--- a/src/static/app/src/components/configurationComponents/peerJobsAllModal.vue
+++ b/src/static/app/src/components/configurationComponents/peerJobsAllModal.vue
@@ -31,7 +31,7 @@ export default {
 						<h4 class="mb-0 fw-normal">
 							<LocaleText t="All Active Jobs"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4 pb-4 pt-2 ">
 						<button class="btn bg-primary-subtle border-1 border-primary-subtle text-primary-emphasis rounded-3 shadow mb-2"

--- a/src/static/app/src/components/configurationComponents/peerJobsLogsModal.vue
+++ b/src/static/app/src/components/configurationComponents/peerJobsLogsModal.vue
@@ -59,7 +59,7 @@ export default {
 						<h4 class="mb-0">
 							<LocaleText t="Jobs Logs"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4 pb-4 pt-2">
 						<div v-if="!this.dataLoading">

--- a/src/static/app/src/components/configurationComponents/peerQRCode.vue
+++ b/src/static/app/src/components/configurationComponents/peerQRCode.vue
@@ -69,7 +69,7 @@ export default {
 						<h4 class="mb-0">
 							<LocaleText t="QR Code"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body p-4">
 						<div class="d-flex gap-2 flex-column">

--- a/src/static/app/src/components/configurationComponents/peerSettings.vue
+++ b/src/static/app/src/components/configurationComponents/peerSettings.vue
@@ -78,7 +78,7 @@ export default {
 						<h4 class="mb-0">
 							<LocaleText t="Peer Settings"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4" v-if="this.data">
 						<div class="d-flex flex-column gap-2 mb-4">

--- a/src/static/app/src/components/configurationComponents/peerSettingsDropdownComponents/peerSettingsDropdownTool.vue
+++ b/src/static/app/src/components/configurationComponents/peerSettingsDropdownComponents/peerSettingsDropdownTool.vue
@@ -14,10 +14,11 @@ const show = ref(false)
 
 <template>
 	<a class="dropdown-item text-center px-0 rounded-3 position-relative" role="button"
+	   :aria-label="title"
 	   @mouseenter="show = true"
 	   @mouseleave="show = false"
 	   @click="emit('click')">
-		<i class="me-auto bi" :class="icon"></i>
+		<i class="me-auto bi" :class="icon" aria-hidden="true"></i>
 		<Transition name="zoomReversed">
 			<span
 				v-if="show"

--- a/src/static/app/src/components/configurationComponents/peerShareLinkModal.vue
+++ b/src/static/app/src/components/configurationComponents/peerShareLinkModal.vue
@@ -115,7 +115,7 @@ export default {
 						<h4 class="mb-0">
 							<LocaleText t="Share Peer"></LocaleText>
 						</h4>
-						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')"></button>
+						<button type="button" class="btn-close ms-auto" @click="this.$emit('close')" aria-label="Close"></button>
 					</div>
 					<div class="card-body px-4 pb-4" v-if="this.selectedPeer.ShareLink">
 						<div v-if="!this.dataCopy">

--- a/src/static/app/src/components/configurationComponents/selectPeers.vue
+++ b/src/static/app/src/components/configurationComponents/selectPeers.vue
@@ -110,7 +110,7 @@ const clearDownload = () => {
 								<LocaleText t="Select Peers"></LocaleText>
 							</h4>
 							<button type="button" class="btn-close ms-auto"
-							        @click="emit('close')"></button>
+							        @click="emit('close')" aria-label="Close"></button>
 						</div>
 						<div class="d-flex w-100 align-items-center gap-2">
 							<div class="d-flex gap-3">


### PR DESCRIPTION
## Summary
Add aria labels to actionable icons in the peer configuration UI (buttons, close icons, and icon‑only controls) to improve accessibility without touching decorative icons.

## What changed
- Added `aria-label` to close buttons in peer/configuration modals.
- Added `aria-label` to the peer action menu trigger and icon‑only dropdown tools.
- Marked purely decorative icons as `aria-hidden`.

## Why this helps
Screen readers can now announce control icons, while decorative icons remain silent, matching the guidance in #750.

## Tests
- `npm run build`

Fixes #750
