### PR TITLE
[FEATURE] Add GCP deployment scripts for one-command setup

### DIFF
--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -1,0 +1,366 @@
+# WireGuard Dashboard - Deploy Scripts
+
+Deploy WireGuard Dashboard with a single command.
+
+## How It Works
+
+```mermaid
+flowchart TB
+    A[🖥️ You want a VPN Server] --> B{Where do you want<br/>to install?}
+
+    B -->|Any Server<br/>AWS, DigitalOcean, VPS, etc| C[Run install.sh]
+    B -->|Google Cloud<br/>Automated| D[Run gcp/run.sh deploy]
+
+    subgraph UNIVERSAL ["🌍 Universal Installation"]
+        C --> C1[SSH into your server]
+        C1 --> C2[Run: curl ... install.sh]
+    end
+
+    subgraph GCP ["☁️ GCP Automated"]
+        D --> D1[Select Region]
+        D1 --> D2[Select Machine Type]
+        D2 --> D3[Script creates VM automatically]
+    end
+
+    C2 --> E[🐳 Docker + WireGuard installed]
+    D3 --> E
+
+    E --> F[🌐 Dashboard Ready!<br/>http://IP:10086]
+    F --> G[📱 Connect your devices]
+```
+
+## Demo
+
+### Installation GCP
+
+https://github.com/user-attachments/assets/90b7976c-69f3-46b5-bab2-bb5e2474e173
+
+
+### Dashboard GCP Navigation
+
+https://github.com/user-attachments/assets/fa34e1a0-13e8-4d66-972c-796b6c8ddf57
+
+## File Structure
+
+```
+scripts/deploy/
+├── README.md           # This file
+├── install.sh          # Universal installation script (any server)
+└── gcp/
+    └── run.sh          # GCP-specific automation tool
+```
+
+---
+
+## Universal Installation (Any Server)
+
+The `install.sh` script works on **any Ubuntu/Debian server** - VPS, bare metal, AWS, Azure, DigitalOcean, Linode, or any cloud provider.
+
+### Quick Start
+
+```bash
+# SSH into your server, then run:
+curl -fsSL https://raw.githubusercontent.com/WGDashboard/WGDashboard/main/scripts/deploy/install.sh | sudo bash
+```
+
+Or download and run manually:
+
+```bash
+curl -O https://raw.githubusercontent.com/WGDashboard/WGDashboard/main/scripts/deploy/install.sh
+chmod +x install.sh
+sudo ./install.sh
+```
+
+### Requirements
+
+- Ubuntu 20.04+ or Debian 11+
+- Root access (sudo)
+- Open ports: `51820/udp` (WireGuard) and `10086/tcp` (Dashboard)
+
+### What It Does
+
+1. Installs Docker and Docker Compose
+2. Configures IP forwarding and iptables
+3. Deploys WireGuard Dashboard container
+4. Sets up automatic firewall rules
+
+### After Installation
+
+```
+DASHBOARD:
+  URL:      http://<YOUR_IP>:10086
+  User:     admin
+  Password: Test123
+
+WIREGUARD:
+  Endpoint: <YOUR_IP>:51820
+```
+
+---
+
+## Google Cloud Platform (Automated)
+
+The `gcp/run.sh` script automates the entire GCP deployment process - creating VMs, configuring firewalls, and installing WireGuard Dashboard.
+
+```mermaid
+flowchart LR
+    subgraph DEPLOY ["🚀 ./run.sh deploy"]
+        A1[Create Firewall Rules] --> A2[Create VM]
+        A2 --> A3[Install WireGuard]
+        A3 --> A4[✅ Ready!]
+    end
+
+    subgraph MANAGE ["🔧 Management"]
+        B1[status] --> B2[Check VM info]
+        B3[ssh] --> B4[Connect to VM]
+        B5[logs] --> B6[View logs]
+        B7[stop] --> B8[Save costs 💰]
+        B9[start] --> B10[Resume VM]
+    end
+
+    subgraph DESTROY ["🗑️ ./run.sh destroy"]
+        C1[Remove VM] --> C2[--all: Remove firewall]
+        C2 --> C3[🧹 Clean!]
+    end
+
+    A4 -.-> MANAGE
+    MANAGE -.-> C1
+```
+
+### Supported Providers
+
+| Provider | Status | Script |
+|----------|--------|--------|
+| Google Cloud (GCP) | Ready | `gcp/run.sh` |
+| AWS | Coming soon | - |
+| Azure | Coming soon | - |
+| DigitalOcean | Coming soon | - |
+
+### Prerequisites
+
+1. **Google Cloud Account** with billing enabled
+2. **gcloud CLI** installed and authenticated
+
+```bash
+# Install gcloud CLI
+# https://cloud.google.com/sdk/docs/install
+
+# Login
+gcloud auth login
+
+# Set default project (optional)
+gcloud config set project YOUR_PROJECT_ID
+```
+
+### Quick Start
+
+```bash
+cd scripts/deploy/gcp
+
+# Interactive deploy (choose region, auto-detect project)
+./run.sh deploy
+
+# Specify project
+./run.sh deploy --project my-gcp-project-id
+
+# Deploy to specific region
+./run.sh deploy --region us-west1
+
+# Full example
+./run.sh deploy --project my-project-123 --region europe-west3
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `deploy` | Create VM and install WireGuard Dashboard |
+| `destroy` | Remove VM and resources |
+| `status` | Show VM status and access info |
+| `ssh` | Connect to VM via SSH |
+| `logs` | View WireGuard Dashboard logs |
+| `start` | Start a stopped VM |
+| `stop` | Stop VM (saves costs) |
+| `regions` | List all available regions |
+| `help` | Show help message |
+
+### Deploy Options
+
+```bash
+# Interactive (select region from menu)
+./run.sh deploy
+
+# Specify region
+./run.sh deploy --region europe-west3
+
+# Specify zone
+./run.sh deploy --zone us-east1-b
+
+# Custom VM name
+./run.sh deploy --name my-vpn-server
+
+# Specify project
+./run.sh deploy --project my-gcp-project
+
+# Combine options
+./run.sh deploy --region asia-northeast1 --name tokyo-vpn
+```
+
+### Management
+
+```bash
+# Check status
+./run.sh status
+
+# Connect via SSH
+./run.sh ssh
+
+# View logs
+./run.sh logs
+
+# Stop VM (saves money when not in use)
+./run.sh stop
+
+# Start VM
+./run.sh start
+```
+
+### Destroy
+
+```bash
+# Remove VM only
+./run.sh destroy
+
+# Remove VM + firewall rules + static IPs
+./run.sh destroy --all
+
+# Skip confirmations
+./run.sh destroy --all --force
+```
+
+### Available Regions
+
+Run `./run.sh regions` to see all available regions, or use:
+
+**Americas:**
+- `us-central1` - Iowa, USA
+- `us-east1` - South Carolina, USA
+- `us-west1` - Oregon, USA
+- `us-west2` - Los Angeles, USA
+- `southamerica-east1` - Sao Paulo, Brazil
+
+**Europe:**
+- `europe-west1` - Belgium
+- `europe-west2` - London, UK
+- `europe-west3` - Frankfurt, Germany
+- `europe-west9` - Paris, France
+
+**Asia Pacific:**
+- `asia-northeast1` - Tokyo, Japan
+- `asia-southeast1` - Singapore
+- `australia-southeast1` - Sydney, Australia
+
+**Middle East & Africa:**
+- `me-west1` - Tel Aviv, Israel
+- `africa-south1` - Johannesburg, South Africa
+
+### Costs
+
+- **VM:** e2-micro is free tier eligible (1 per month)
+- **Network:** Egress charges apply for VPN traffic
+- **Disk:** 10GB standard disk (~$0.40/month)
+
+**Tip:** Use `./run.sh stop` when not using the VPN to save costs.
+
+---
+
+## After Deployment
+
+Once deployed, you'll receive:
+
+```
+DASHBOARD:
+  URL:      http://<IP>:10086
+  User:     admin
+  Password: Test123
+
+WIREGUARD:
+  Endpoint: <IP>:51820
+```
+
+**First-time setup:**
+
+1. Access the dashboard URL
+2. Login with `admin` / `Test123`
+3. Go to **Server Configuration**
+4. Set the endpoint to your VM's IP
+5. Create peers (clients) to connect
+
+---
+
+## Troubleshooting
+
+### "gcloud CLI not found"
+
+Install the Google Cloud SDK:
+```bash
+# macOS
+brew install google-cloud-sdk
+
+# Or download from:
+# https://cloud.google.com/sdk/docs/install
+```
+
+### "Not logged into gcloud"
+
+```bash
+gcloud auth login
+```
+
+### "Cannot access project"
+
+Make sure you have the correct permissions:
+```bash
+gcloud projects list
+gcloud config set project YOUR_PROJECT_ID
+```
+
+### VM created but can't connect
+
+1. Check firewall rules exist:
+   ```bash
+   gcloud compute firewall-rules list | grep wireguard
+   ```
+
+2. Check VM is running:
+   ```bash
+   ./run.sh status
+   ```
+
+3. Wait a few minutes for installation to complete
+
+### Dashboard not loading
+
+SSH into VM and check logs:
+```bash
+./run.sh ssh
+cd /opt/wgdashboard
+sudo docker-compose logs
+```
+
+---
+
+## Contributing
+
+To add support for a new cloud provider:
+
+1. Create a new directory: `scripts/deploy/<provider>/`
+2. Create `run.sh` with the same command structure
+3. Use `../install.sh` for the base WireGuard installation
+4. Update this README
+
+---
+
+## License
+
+MIT License - See repository root for details.

--- a/scripts/deploy/gcp/run.sh
+++ b/scripts/deploy/gcp/run.sh
@@ -1,0 +1,816 @@
+#!/bin/bash
+
+# ===========================================
+# WireGuard Dashboard - GCP Deploy Tool
+# ===========================================
+#
+# Usage:
+#   ./run.sh deploy                     # Deploy new VM (interactive)
+#   ./run.sh deploy --region us-west1   # Deploy to specific region
+#   ./run.sh destroy                    # Remove VM
+#   ./run.sh destroy --all              # Remove VM + firewall + IPs
+#   ./run.sh status                     # Show VM status
+#   ./run.sh ssh                        # Connect to VM
+#   ./run.sh logs                       # View container logs
+#   ./run.sh regions                    # List all regions
+#   ./run.sh help                       # Show help
+
+set -e
+
+# ===========================================
+# CONFIGURATION
+# ===========================================
+
+PROJECT_ID=""
+DEFAULT_REGION="us-central1"
+DEFAULT_NAME="wireguard-vpn"
+DEFAULT_MACHINE_TYPE="e2-micro"
+IMAGE_FAMILY="ubuntu-2404-lts-amd64"
+IMAGE_PROJECT="ubuntu-os-cloud"
+
+# Machine types with pricing (approximate monthly cost in USD)
+# Format: "type:vCPUs:RAM:monthly_price:description"
+MACHINE_TYPES=(
+    "e2-micro:0.25 vCPU:1 GB:FREE:Free tier (1 instance/month)"
+    "e2-small:0.5 vCPU:2 GB:\$12/mo:Good for personal use"
+    "e2-medium:1 vCPU:4 GB:\$24/mo:Small teams (5-10 users)"
+    "e2-standard-2:2 vCPUs:8 GB:\$48/mo:Medium teams (10-25 users)"
+    "e2-standard-4:4 vCPUs:16 GB:\$96/mo:Large teams (25-50 users)"
+    "e2-standard-8:8 vCPUs:32 GB:\$192/mo:Enterprise (50+ users)"
+)
+
+# Regions by area
+AMERICAS_REGIONS=(
+    "us-central1:Iowa, USA"
+    "us-east1:South Carolina, USA"
+    "us-east4:Virginia, USA"
+    "us-east5:Columbus, USA"
+    "us-west1:Oregon, USA"
+    "us-west2:Los Angeles, USA"
+    "us-west3:Salt Lake City, USA"
+    "us-west4:Las Vegas, USA"
+    "us-south1:Dallas, USA"
+    "northamerica-northeast1:Montreal, Canada"
+    "northamerica-northeast2:Toronto, Canada"
+    "southamerica-east1:Sao Paulo, Brazil"
+    "southamerica-west1:Santiago, Chile"
+)
+
+EUROPE_REGIONS=(
+    "europe-west1:Belgium"
+    "europe-west2:London, UK"
+    "europe-west3:Frankfurt, Germany"
+    "europe-west4:Netherlands"
+    "europe-west6:Zurich, Switzerland"
+    "europe-west8:Milan, Italy"
+    "europe-west9:Paris, France"
+    "europe-west10:Berlin, Germany"
+    "europe-west12:Turin, Italy"
+    "europe-north1:Finland"
+    "europe-central2:Warsaw, Poland"
+    "europe-southwest1:Madrid, Spain"
+)
+
+ASIA_REGIONS=(
+    "asia-east1:Taiwan"
+    "asia-east2:Hong Kong"
+    "asia-northeast1:Tokyo, Japan"
+    "asia-northeast2:Osaka, Japan"
+    "asia-northeast3:Seoul, South Korea"
+    "asia-south1:Mumbai, India"
+    "asia-south2:Delhi, India"
+    "asia-southeast1:Singapore"
+    "asia-southeast2:Jakarta, Indonesia"
+    "australia-southeast1:Sydney, Australia"
+    "australia-southeast2:Melbourne, Australia"
+)
+
+MIDDLE_EAST_REGIONS=(
+    "me-west1:Tel Aviv, Israel"
+    "me-central1:Doha, Qatar"
+    "me-central2:Dammam, Saudi Arabia"
+    "africa-south1:Johannesburg, South Africa"
+)
+
+ALL_REGIONS=(
+    "${AMERICAS_REGIONS[@]}"
+    "${EUROPE_REGIONS[@]}"
+    "${ASIA_REGIONS[@]}"
+    "${MIDDLE_EAST_REGIONS[@]}"
+)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SCRIPT="$DEPLOY_DIR/install.sh"
+
+# ===========================================
+# VARIABLES
+# ===========================================
+
+COMMAND=""
+VM_NAME="$DEFAULT_NAME"
+REGION="$DEFAULT_REGION"
+ZONE=""
+MACHINE_TYPE="$DEFAULT_MACHINE_TYPE"
+FORCE=false
+REMOVE_ALL=false
+INTERACTIVE=true
+
+# ===========================================
+# HELPER FUNCTIONS
+# ===========================================
+
+print_header() {
+    echo ""
+    echo "=========================================="
+    echo "  $1"
+    echo "=========================================="
+    echo ""
+}
+
+print_usage() {
+    cat << 'EOF'
+WireGuard Dashboard - GCP Deploy Tool
+
+USAGE:
+    ./run.sh <command> [options]
+
+COMMANDS:
+    deploy      Create VM and install WireGuard Dashboard
+    destroy     Remove VM and optionally other resources
+    status      Show current VM status and info
+    ssh         SSH into the VM
+    logs        View WireGuard Dashboard logs
+    start       Start a stopped VM
+    stop        Stop the VM (saves costs)
+    regions     List all available regions
+    help        Show this help message
+
+DEPLOY OPTIONS:
+    -r, --region REGION    GCP region (default: us-central1)
+    -z, --zone ZONE        GCP zone (overrides region)
+    -n, --name NAME        VM instance name (default: wireguard-vpn)
+    -p, --project ID       GCP project ID (auto-detected)
+    -t, --type TYPE        Machine type (default: e2-micro)
+
+DESTROY OPTIONS:
+    -a, --all              Remove VM + firewall rules + static IPs
+    -f, --force            Skip confirmation prompts
+    -n, --name NAME        VM instance name
+    -p, --project ID       GCP project ID
+
+EXAMPLES:
+    ./run.sh deploy                           # Interactive deploy
+    ./run.sh deploy --region europe-west3     # Deploy to Frankfurt
+    ./run.sh deploy --region asia-northeast1  # Deploy to Tokyo
+    ./run.sh status                           # Check VM status
+    ./run.sh ssh                              # Connect to VM
+    ./run.sh logs                             # View logs
+    ./run.sh stop                             # Stop VM
+    ./run.sh start                            # Start VM
+    ./run.sh destroy                          # Remove VM only
+    ./run.sh destroy --all --force            # Remove everything
+
+EOF
+}
+
+check_gcloud() {
+    if ! command -v gcloud &> /dev/null; then
+        echo "ERROR: gcloud CLI not found"
+        echo "Install: https://cloud.google.com/sdk/docs/install"
+        exit 1
+    fi
+
+    if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null | head -1 | grep -q "@"; then
+        echo "ERROR: Not logged into gcloud"
+        echo "Run: gcloud auth login"
+        exit 1
+    fi
+}
+
+get_project() {
+    if [ -n "$PROJECT_ID" ]; then
+        return 0
+    fi
+
+    PROJECT_ID=$(gcloud config get-value project 2>/dev/null)
+
+    if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "(unset)" ]; then
+        echo ""
+        echo "Available projects:"
+        gcloud projects list --format="table(projectId,name)" 2>/dev/null | head -20
+        echo ""
+        read -p "Enter GCP Project ID: " PROJECT_ID
+
+        if [ -z "$PROJECT_ID" ]; then
+            echo "ERROR: Project ID is required"
+            exit 1
+        fi
+    fi
+
+    if ! gcloud projects describe "$PROJECT_ID" &>/dev/null; then
+        echo "ERROR: Cannot access project '$PROJECT_ID'"
+        exit 1
+    fi
+}
+
+find_vm() {
+    if [ -z "$ZONE" ]; then
+        local vm_info=$(gcloud compute instances list \
+            --project="$PROJECT_ID" \
+            --filter="name=$VM_NAME" \
+            --format="value(name,zone)" 2>/dev/null | head -1)
+
+        if [ -z "$vm_info" ]; then
+            return 1
+        fi
+
+        ZONE=$(echo "$vm_info" | awk '{print $2}' | rev | cut -d'/' -f1 | rev)
+    else
+        if ! gcloud compute instances describe "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" &>/dev/null; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
+get_vm_ip() {
+    gcloud compute instances describe "$VM_NAME" \
+        --zone="$ZONE" \
+        --project="$PROJECT_ID" \
+        --format="value(networkInterfaces[0].accessConfigs[0].natIP)" 2>/dev/null
+}
+
+get_zone_for_region() {
+    gcloud compute zones list --filter="region:$1" --format="value(name)" 2>/dev/null | head -1
+}
+
+# ===========================================
+# COMMAND: REGIONS
+# ===========================================
+
+cmd_regions() {
+    print_header "AVAILABLE REGIONS"
+
+    echo "AMERICAS:"
+    for r in "${AMERICAS_REGIONS[@]}"; do
+        printf "  %-28s (%s)\n" "${r%%:*}" "${r##*:}"
+    done
+
+    echo ""
+    echo "EUROPE:"
+    for r in "${EUROPE_REGIONS[@]}"; do
+        printf "  %-28s (%s)\n" "${r%%:*}" "${r##*:}"
+    done
+
+    echo ""
+    echo "ASIA PACIFIC:"
+    for r in "${ASIA_REGIONS[@]}"; do
+        printf "  %-28s (%s)\n" "${r%%:*}" "${r##*:}"
+    done
+
+    echo ""
+    echo "MIDDLE EAST & AFRICA:"
+    for r in "${MIDDLE_EAST_REGIONS[@]}"; do
+        printf "  %-28s (%s)\n" "${r%%:*}" "${r##*:}"
+    done
+
+    echo ""
+    echo "Usage: ./run.sh deploy --region <region-code>"
+}
+
+select_region() {
+    print_header "SELECT REGION"
+
+    local i=1
+
+    echo "AMERICAS:"
+    for r in "${AMERICAS_REGIONS[@]}"; do
+        printf "  %2d) %-28s (%s)\n" $i "${r%%:*}" "${r##*:}"
+        ((i++))
+    done
+
+    echo ""
+    echo "EUROPE:"
+    for r in "${EUROPE_REGIONS[@]}"; do
+        printf "  %2d) %-28s (%s)\n" $i "${r%%:*}" "${r##*:}"
+        ((i++))
+    done
+
+    echo ""
+    echo "ASIA PACIFIC:"
+    for r in "${ASIA_REGIONS[@]}"; do
+        printf "  %2d) %-28s (%s)\n" $i "${r%%:*}" "${r##*:}"
+        ((i++))
+    done
+
+    echo ""
+    echo "MIDDLE EAST & AFRICA:"
+    for r in "${MIDDLE_EAST_REGIONS[@]}"; do
+        printf "  %2d) %-28s (%s)\n" $i "${r%%:*}" "${r##*:}"
+        ((i++))
+    done
+
+    local total=${#ALL_REGIONS[@]}
+    echo ""
+    read -p "Select region [1-$total] (default: 1): " selection
+
+    if [ -z "$selection" ]; then
+        selection=1
+    fi
+
+    if [[ "$selection" =~ ^[0-9]+$ ]] && [ "$selection" -ge 1 ] && [ "$selection" -le "$total" ]; then
+        local selected="${ALL_REGIONS[$((selection-1))]}"
+        REGION="${selected%%:*}"
+        echo "Selected: $REGION (${selected##*:})"
+    else
+        REGION="$DEFAULT_REGION"
+    fi
+}
+
+select_machine_type() {
+    print_header "SELECT MACHINE TYPE"
+
+    echo "Available instance types:"
+    echo ""
+    printf "  %-3s %-16s %-10s %-8s %-12s %s\n" "#" "TYPE" "vCPUs" "RAM" "PRICE" "DESCRIPTION"
+    printf "  %-3s %-16s %-10s %-8s %-12s %s\n" "---" "----------------" "----------" "--------" "------------" "-------------------------"
+
+    local i=1
+    for m in "${MACHINE_TYPES[@]}"; do
+        IFS=':' read -r type vcpu ram price desc <<< "$m"
+        if [ "$price" = "FREE" ]; then
+            printf "  %-3s %-16s %-10s %-8s \033[32m%-12s\033[0m %s\n" "$i)" "$type" "$vcpu" "$ram" "$price" "$desc"
+        else
+            printf "  %-3s %-16s %-10s %-8s %-12s %s\n" "$i)" "$type" "$vcpu" "$ram" "$price" "$desc"
+        fi
+        ((i++))
+    done
+
+    local total=${#MACHINE_TYPES[@]}
+    echo ""
+    read -p "Select machine type [1-$total] (default: 1 - FREE): " selection
+
+    if [ -z "$selection" ]; then
+        selection=1
+    fi
+
+    if [[ "$selection" =~ ^[0-9]+$ ]] && [ "$selection" -ge 1 ] && [ "$selection" -le "$total" ]; then
+        local selected="${MACHINE_TYPES[$((selection-1))]}"
+        MACHINE_TYPE="${selected%%:*}"
+        IFS=':' read -r type vcpu ram price desc <<< "$selected"
+        echo "Selected: $MACHINE_TYPE ($vcpu, $ram) - $price"
+    else
+        MACHINE_TYPE="$DEFAULT_MACHINE_TYPE"
+        echo "Using default: $MACHINE_TYPE"
+    fi
+}
+
+# ===========================================
+# COMMAND: DEPLOY
+# ===========================================
+
+cmd_deploy() {
+    print_header "WIREGUARD VPN - DEPLOY"
+
+    check_gcloud
+    get_project
+
+    echo "Project: $PROJECT_ID"
+
+    if [ "$INTERACTIVE" = true ]; then
+        select_region
+        select_machine_type
+    fi
+
+    if [ -z "$ZONE" ]; then
+        ZONE=$(get_zone_for_region "$REGION")
+    fi
+
+    echo ""
+    echo "Configuration:"
+    echo "  Project: $PROJECT_ID"
+    echo "  Region:  $REGION"
+    echo "  Zone:    $ZONE"
+    echo "  VM Name: $VM_NAME"
+    echo "  Type:    $MACHINE_TYPE"
+    echo ""
+
+    read -p "Continue? [Y/n]: " confirm
+    if [[ "$confirm" =~ ^[Nn]$ ]]; then
+        echo "Cancelled."
+        exit 0
+    fi
+
+    # Create firewall rules
+    print_header "CONFIGURING FIREWALL"
+    if gcloud compute firewall-rules describe wireguard-vpn --project="$PROJECT_ID" &>/dev/null; then
+        echo "OK: Firewall rule already exists"
+    else
+        echo "Creating firewall rule..."
+        gcloud compute firewall-rules create wireguard-vpn \
+            --project="$PROJECT_ID" \
+            --direction=INGRESS \
+            --priority=1000 \
+            --network=default \
+            --action=ALLOW \
+            --rules=udp:51820,tcp:10086 \
+            --source-ranges=0.0.0.0/0 \
+            --target-tags=wireguard \
+            --description="WireGuard VPN and Dashboard"
+        echo "OK: Firewall rule created"
+    fi
+
+    # Create VM
+    print_header "CREATING VM"
+    if gcloud compute instances describe "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" &>/dev/null; then
+        echo "VM '$VM_NAME' already exists"
+        read -p "Delete and recreate? [y/N]: " confirm
+        if [[ "$confirm" =~ ^[Yy]$ ]]; then
+            gcloud compute instances delete "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --quiet
+        else
+            echo "Using existing VM..."
+        fi
+    fi
+
+    if ! gcloud compute instances describe "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" &>/dev/null; then
+        echo "Creating VM..."
+        gcloud compute instances create "$VM_NAME" \
+            --project="$PROJECT_ID" \
+            --zone="$ZONE" \
+            --machine-type="$MACHINE_TYPE" \
+            --image-family="$IMAGE_FAMILY" \
+            --image-project="$IMAGE_PROJECT" \
+            --boot-disk-size=10GB \
+            --boot-disk-type=pd-standard \
+            --can-ip-forward \
+            --tags=wireguard
+
+        echo "Waiting for VM to be ready..."
+        sleep 30
+    fi
+
+    # Deploy WireGuard
+    print_header "INSTALLING WIREGUARD"
+
+    local vm_ip=$(get_vm_ip)
+    echo "VM IP: $vm_ip"
+    echo ""
+
+    if [ ! -f "$INSTALL_SCRIPT" ]; then
+        echo "ERROR: install.sh not found"
+        exit 1
+    fi
+
+    echo "[1/5] Uploading install script..."
+    echo "----------------------------------------"
+    gcloud compute scp "$INSTALL_SCRIPT" "$VM_NAME:/tmp/install.sh" \
+        --zone="$ZONE" --project="$PROJECT_ID"
+    echo "----------------------------------------"
+    echo ""
+
+    echo "[2/5] Updating system packages..."
+    echo "----------------------------------------"
+    gcloud compute ssh "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --command="
+        sudo apt-get update
+    "
+    echo "----------------------------------------"
+    echo ""
+
+    echo "[3/5] Installing iptables-persistent..."
+    echo "----------------------------------------"
+    gcloud compute ssh "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --command="
+        export DEBIAN_FRONTEND=noninteractive
+        export DEBCONF_NONINTERACTIVE_SEEN=true
+        echo iptables-persistent iptables-persistent/autosave_v4 boolean true | sudo debconf-set-selections
+        echo iptables-persistent iptables-persistent/autosave_v6 boolean true | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            -o Dpkg::Options::='--force-confdef' \
+            -o Dpkg::Options::='--force-confold' \
+            iptables-persistent netfilter-persistent || true
+    "
+    echo "----------------------------------------"
+    echo ""
+
+    echo "[4/5] Installing WireGuard Dashboard..."
+    echo "----------------------------------------"
+    gcloud compute ssh "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --command="
+        sudo bash /tmp/install.sh
+    "
+    echo "----------------------------------------"
+    echo ""
+
+    echo "[5/5] Saving firewall rules..."
+    echo "----------------------------------------"
+    gcloud compute ssh "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --command="
+        sudo netfilter-persistent save || true
+    "
+    echo "----------------------------------------"
+
+    # Done
+    print_header "DEPLOYMENT COMPLETE"
+
+    echo "DASHBOARD:"
+    echo "  URL:      http://$vm_ip:10086"
+    echo "  User:     admin"
+    echo "  Password: Test123"
+    echo ""
+    echo "WIREGUARD:"
+    echo "  Endpoint: $vm_ip:51820"
+    echo ""
+    echo "COMMANDS:"
+    echo "  ./run.sh status    # Check status"
+    echo "  ./run.sh ssh       # Connect to VM"
+    echo "  ./run.sh logs      # View logs"
+    echo "  ./run.sh stop      # Stop VM"
+    echo "  ./run.sh destroy   # Remove VM"
+    echo ""
+}
+
+# ===========================================
+# COMMAND: DESTROY
+# ===========================================
+
+cmd_destroy() {
+    print_header "WIREGUARD VPN - DESTROY"
+
+    check_gcloud
+    get_project
+
+    echo "Project: $PROJECT_ID"
+
+    # Find VM
+    if find_vm; then
+        echo "Found VM: $VM_NAME in $ZONE"
+
+        local vm_ip=$(get_vm_ip)
+        echo "IP: $vm_ip"
+        echo ""
+
+        if [ "$FORCE" != true ]; then
+            read -p "Delete VM '$VM_NAME'? [y/N]: " confirm
+            if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                echo "Skipped VM deletion"
+            else
+                echo "Deleting VM..."
+                gcloud compute instances delete "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --quiet
+                echo "OK: VM deleted"
+            fi
+        else
+            echo "Deleting VM..."
+            gcloud compute instances delete "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --quiet
+            echo "OK: VM deleted"
+        fi
+    else
+        echo "VM '$VM_NAME' not found"
+    fi
+
+    # Remove firewall and IPs if --all
+    if [ "$REMOVE_ALL" = true ]; then
+        echo ""
+        if gcloud compute firewall-rules describe wireguard-vpn --project="$PROJECT_ID" &>/dev/null; then
+            if [ "$FORCE" = true ]; then
+                gcloud compute firewall-rules delete wireguard-vpn --project="$PROJECT_ID" --quiet
+                echo "OK: Firewall rule deleted"
+            else
+                read -p "Delete firewall rule 'wireguard-vpn'? [y/N]: " confirm
+                if [[ "$confirm" =~ ^[Yy]$ ]]; then
+                    gcloud compute firewall-rules delete wireguard-vpn --project="$PROJECT_ID" --quiet
+                    echo "OK: Firewall rule deleted"
+                fi
+            fi
+        fi
+
+        # Check for static IPs
+        local static_ips=$(gcloud compute addresses list --project="$PROJECT_ID" --filter="name~wireguard" --format="value(name,region)" 2>/dev/null)
+        if [ -n "$static_ips" ]; then
+            echo ""
+            echo "Found static IPs:"
+            echo "$static_ips"
+            if [ "$FORCE" = true ]; then
+                echo "$static_ips" | while read -r name region; do
+                    [ -n "$name" ] && gcloud compute addresses delete "$name" --region="$region" --project="$PROJECT_ID" --quiet 2>/dev/null || true
+                done
+                echo "OK: Static IPs deleted"
+            else
+                read -p "Delete static IPs? [y/N]: " confirm
+                if [[ "$confirm" =~ ^[Yy]$ ]]; then
+                    echo "$static_ips" | while read -r name region; do
+                        [ -n "$name" ] && gcloud compute addresses delete "$name" --region="$region" --project="$PROJECT_ID" --quiet 2>/dev/null || true
+                    done
+                    echo "OK: Static IPs deleted"
+                fi
+            fi
+        fi
+    fi
+
+    print_header "DESTROY COMPLETE"
+    echo "To redeploy: ./run.sh deploy"
+}
+
+# ===========================================
+# COMMAND: STATUS
+# ===========================================
+
+cmd_status() {
+    print_header "WIREGUARD VPN - STATUS"
+
+    check_gcloud
+    get_project
+
+    echo "Project: $PROJECT_ID"
+    echo ""
+
+    if find_vm; then
+        local vm_ip=$(get_vm_ip)
+        local status=$(gcloud compute instances describe "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" --format="value(status)" 2>/dev/null)
+
+        echo "VM:"
+        echo "  Name:   $VM_NAME"
+        echo "  Zone:   $ZONE"
+        echo "  Status: $status"
+        echo "  IP:     $vm_ip"
+        echo ""
+
+        if [ "$status" = "RUNNING" ]; then
+            echo "DASHBOARD:"
+            echo "  URL: http://$vm_ip:10086"
+            echo ""
+            echo "WIREGUARD:"
+            echo "  Endpoint: $vm_ip:51820"
+        fi
+    else
+        echo "VM '$VM_NAME' not found in project"
+        echo ""
+        echo "To deploy: ./run.sh deploy"
+    fi
+}
+
+# ===========================================
+# COMMAND: SSH
+# ===========================================
+
+cmd_ssh() {
+    check_gcloud
+    get_project
+
+    if ! find_vm; then
+        echo "ERROR: VM '$VM_NAME' not found"
+        exit 1
+    fi
+
+    echo "Connecting to $VM_NAME..."
+    gcloud compute ssh "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID"
+}
+
+# ===========================================
+# COMMAND: LOGS
+# ===========================================
+
+cmd_logs() {
+    check_gcloud
+    get_project
+
+    if ! find_vm; then
+        echo "ERROR: VM '$VM_NAME' not found"
+        exit 1
+    fi
+
+    echo "Fetching logs from $VM_NAME..."
+    gcloud compute ssh "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID" \
+        --command="cd /opt/wgdashboard && sudo docker-compose logs -f --tail=100"
+}
+
+# ===========================================
+# COMMAND: START
+# ===========================================
+
+cmd_start() {
+    check_gcloud
+    get_project
+
+    if ! find_vm; then
+        echo "ERROR: VM '$VM_NAME' not found"
+        exit 1
+    fi
+
+    echo "Starting $VM_NAME..."
+    gcloud compute instances start "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID"
+    echo "OK: VM started"
+
+    sleep 10
+    local vm_ip=$(get_vm_ip)
+    echo ""
+    echo "Dashboard: http://$vm_ip:10086"
+}
+
+# ===========================================
+# COMMAND: STOP
+# ===========================================
+
+cmd_stop() {
+    check_gcloud
+    get_project
+
+    if ! find_vm; then
+        echo "ERROR: VM '$VM_NAME' not found"
+        exit 1
+    fi
+
+    echo "Stopping $VM_NAME..."
+    gcloud compute instances stop "$VM_NAME" --zone="$ZONE" --project="$PROJECT_ID"
+    echo "OK: VM stopped (saves costs)"
+}
+
+# ===========================================
+# ARGUMENT PARSING
+# ===========================================
+
+# Get command
+COMMAND="${1:-}"
+shift 2>/dev/null || true
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --region|-r)
+            REGION="$2"
+            INTERACTIVE=false
+            shift 2
+            ;;
+        --zone|-z)
+            ZONE="$2"
+            REGION="${ZONE%-*}"
+            INTERACTIVE=false
+            shift 2
+            ;;
+        --name|-n)
+            VM_NAME="$2"
+            shift 2
+            ;;
+        --project|-p)
+            PROJECT_ID="$2"
+            shift 2
+            ;;
+        --type|-t)
+            MACHINE_TYPE="$2"
+            INTERACTIVE=false
+            shift 2
+            ;;
+        --force|-f)
+            FORCE=true
+            shift
+            ;;
+        --all|-a)
+            REMOVE_ALL=true
+            shift
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# ===========================================
+# MAIN
+# ===========================================
+
+case "$COMMAND" in
+    deploy|install)
+        cmd_deploy
+        ;;
+    destroy|uninstall|remove)
+        cmd_destroy
+        ;;
+    status|info)
+        cmd_status
+        ;;
+    ssh|connect)
+        cmd_ssh
+        ;;
+    logs|log)
+        cmd_logs
+        ;;
+    start)
+        cmd_start
+        ;;
+    stop)
+        cmd_stop
+        ;;
+    regions|region)
+        cmd_regions
+        ;;
+    help|--help|-h|"")
+        print_usage
+        ;;
+    *)
+        echo "Unknown command: $COMMAND"
+        echo "Run './run.sh help' for usage"
+        exit 1
+        ;;
+esac

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+
+# UNIVERSAL WireGuard Dashboard Installation Script
+# Works on Ubuntu AND Debian automatically
+# Detects OS and uses the correct repository
+# Password: Test123
+
+set -e
+
+echo "UNIVERSAL WIREGUARD DASHBOARD INSTALLATION"
+echo "==========================================="
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "ERROR: Run as root: sudo bash install_universal.sh"
+    exit 1
+fi
+
+# Status check function
+check_status() {
+    if [ $? -eq 0 ]; then
+        echo "OK: $1"
+    else
+        echo "ERROR: $1"
+        exit 1
+    fi
+}
+
+# Detect operating system
+echo "DETECTION: Identifying operating system..."
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS=$ID
+    VERSION=$VERSION_ID
+    CODENAME=$VERSION_CODENAME
+else
+    echo "ERROR: Could not detect operating system"
+    exit 1
+fi
+
+echo "Detected system: $OS $VERSION ($CODENAME)"
+
+# Set variables based on OS
+case $OS in
+    "ubuntu")
+        DOCKER_REPO="ubuntu"
+        RELEASE_NAME=$(lsb_release -cs)
+        ;;
+    "debian")
+        DOCKER_REPO="debian"
+        RELEASE_NAME=$(lsb_release -cs)
+        ;;
+    *)
+        echo "ERROR: Unsupported operating system: $OS"
+        echo "Use Ubuntu or Debian"
+        exit 1
+        ;;
+esac
+
+echo "Configuration: Docker for $DOCKER_REPO, release: $RELEASE_NAME"
+
+echo "CLEANUP: Removing previous installation..."
+# Stop and remove existing containers
+docker-compose -f /opt/wgdashboard/docker-compose.yml down 2>/dev/null || true
+docker rm -f wgdashboard 2>/dev/null || true
+docker rmi ghcr.io/wgdashboard/wgdashboard:latest 2>/dev/null || true
+docker rmi donaldzou/wgdashboard:latest 2>/dev/null || true
+
+# Remove old directories
+rm -rf /opt/wgdashboard
+rm -rf /etc/wireguard
+
+# Clean old Docker repositories (issues)
+rm -f /etc/apt/sources.list.d/docker.list
+rm -f /usr/share/keyrings/docker-archive-keyring.gpg
+
+echo "OK: Cleanup completed"
+
+echo "UPDATE: System..."
+apt update && apt upgrade -y
+check_status "System update"
+
+echo "INSTALL: Basic dependencies..."
+apt install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release \
+    software-properties-common \
+    net-tools
+check_status "Basic dependencies"
+
+echo "DOCKER: Removing old versions..."
+apt remove -y docker docker-engine docker.io containerd runc 2>/dev/null || true
+
+echo "DOCKER: Adding official repository for $DOCKER_REPO..."
+curl -fsSL https://download.docker.com/linux/$DOCKER_REPO/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+check_status "Docker GPG key"
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/$DOCKER_REPO $RELEASE_NAME stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+check_status "Docker repository"
+
+echo "DOCKER: Installing..."
+apt update
+apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+check_status "Docker installation"
+
+systemctl start docker
+systemctl enable docker
+check_status "Docker enabled"
+
+echo "DOCKER: Installing Docker Compose..."
+curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
+check_status "Docker Compose"
+
+echo "NETWORK: Configuring IP forwarding..."
+sysctl -w net.ipv4.ip_forward=1
+sysctl -w net.ipv4.conf.all.src_valid_mark=1
+echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/99-wireguard.conf
+echo 'net.ipv4.conf.all.src_valid_mark=1' >> /etc/sysctl.d/99-wireguard.conf
+sysctl -p /etc/sysctl.d/99-wireguard.conf
+check_status "IP forwarding"
+
+echo "FIREWALL: Configuring (universal method)..."
+# Universal method without UFW (for compatibility)
+# Discover main interface
+MAIN_INTERFACE=$(ip route | grep default | awk '{print $5}' | head -1)
+echo "Main interface detected: $MAIN_INTERFACE"
+
+# Configure iptables
+iptables -t nat -F POSTROUTING 2>/dev/null || true
+iptables -t nat -A POSTROUTING -s 10.13.13.0/24 -o $MAIN_INTERFACE -j MASQUERADE
+iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o $MAIN_INTERFACE -j MASQUERADE
+iptables -A FORWARD -i wg+ -j ACCEPT 2>/dev/null || true
+iptables -A FORWARD -o wg+ -j ACCEPT 2>/dev/null || true
+iptables -A INPUT -p udp --dport 51820 -j ACCEPT 2>/dev/null || true
+iptables -A INPUT -p tcp --dport 10086 -j ACCEPT 2>/dev/null || true
+check_status "Network configuration"
+
+echo "SETUP: Creating directory structure..."
+mkdir -p /opt/wgdashboard
+cd /opt/wgdashboard
+check_status "Directory creation"
+
+echo "SETUP: Creating docker-compose.yml (based on official ./docker/compose.yaml)..."
+cat > docker-compose.yml << 'EOF'
+services:
+  wgdashboard:
+    image: ghcr.io/wgdashboard/wgdashboard:latest
+    restart: unless-stopped
+    container_name: wgdashboard
+    ports:
+      - 10086:10086/tcp
+      - 51820:51820/udp
+    volumes:
+      - aconf:/etc/amnezia/amneziawg
+      - conf:/etc/wireguard
+      - data:/data
+    cap_add:
+      - NET_ADMIN
+
+volumes:
+  aconf:
+  conf:
+  data:
+EOF
+check_status "docker-compose.yml creation"
+
+echo "WIREGUARD: Downloading and starting..."
+docker-compose pull
+check_status "Image download"
+
+docker-compose up -d
+check_status "Container initialization"
+
+echo "WAITING: Full initialization (60 seconds)..."
+sleep 60
+
+# Check if container is running
+if ! docker ps | grep -q wgdashboard; then
+    echo "ERROR: Container is not running. Logs:"
+    docker-compose logs
+    exit 1
+fi
+
+# Create persistence script for iptables
+cat > /etc/rc.local << EOF
+#!/bin/bash
+# Restore iptables rules for WireGuard
+sleep 10
+MAIN_INTERFACE=\$(ip route | grep default | awk '{print \$5}' | head -1)
+iptables -t nat -F POSTROUTING 2>/dev/null || true
+iptables -t nat -A POSTROUTING -s 10.13.13.0/24 -o \$MAIN_INTERFACE -j MASQUERADE
+iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o \$MAIN_INTERFACE -j MASQUERADE
+iptables -A FORWARD -i wg+ -j ACCEPT 2>/dev/null || true
+iptables -A FORWARD -o wg+ -j ACCEPT 2>/dev/null || true
+iptables -A INPUT -p udp --dport 51820 -j ACCEPT 2>/dev/null || true
+iptables -A INPUT -p tcp --dport 10086 -j ACCEPT 2>/dev/null || true
+exit 0
+EOF
+chmod +x /etc/rc.local
+
+# Final verification
+if docker ps | grep -q wgdashboard; then
+    echo "OK: WireGuard Dashboard running!"
+else
+    echo "ERROR: Initialization problem"
+    docker-compose logs --tail 50
+    exit 1
+fi
+
+# Get public IP
+PUBLIC_IP=$(curl -s ifconfig.me 2>/dev/null || curl -s ipinfo.io/ip 2>/dev/null || echo "YOUR_PUBLIC_IP")
+
+echo
+echo "UNIVERSAL INSTALLATION COMPLETED!"
+echo "=================================="
+echo
+echo "SYSTEM: $OS $VERSION ($CODENAME)"
+echo "DASHBOARD ACCESS:"
+echo "   URL: http://$PUBLIC_IP:10086"
+echo "   Username: admin"
+echo "   Password: Test123"
+echo
+echo "REQUIRED INITIAL CONFIGURATION:"
+echo "   1. Access the dashboard"
+echo "   2. Go to 'Server Configuration'"
+echo "   3. Configure:"
+echo "      - Endpoint: $PUBLIC_IP:51820"
+echo "      - Address: 10.13.13.1/24"
+echo "      - Listen Port: 51820"
+echo "      - DNS: 8.8.8.8, 8.8.4.4"
+echo "   4. Save the configuration"
+echo "   5. Create a peer to test"
+echo
+echo "USEFUL COMMANDS:"
+echo "   # View logs:"
+echo "   cd /opt/wgdashboard && docker-compose logs -f"
+echo
+echo "   # Restart:"
+echo "   cd /opt/wgdashboard && docker-compose restart"
+echo
+echo "   # Status:"
+echo "   docker ps | grep wgdashboard"
+echo
+echo "   # Check WireGuard:"
+echo "   docker exec wgdashboard wg show"
+echo
+echo "CURRENT STATUS:"
+echo "==============="
+echo "System: $OS $VERSION"
+echo "Container: $(docker ps --format 'table {{.Names}}\t{{.Status}}' | grep wgdashboard)"
+echo "IP Forwarding: $(sysctl -n net.ipv4.ip_forward)"
+echo "Interface: $MAIN_INTERFACE"
+echo
+echo "ACCESS NOW: http://$PUBLIC_IP:10086"
+echo "Login: admin / Test123"


### PR DESCRIPTION
## Summary

Add deployment automation for Google Cloud Platform that allows users to deploy WireGuard Dashboard with a single command.

## Demo

### Installation

https://github.com/user-attachments/assets/90b7976c-69f3-46b5-bab2-bb5e2474e173


### Dashboard Navigation

https://github.com/user-attachments/assets/fa34e1a0-13e8-4d66-972c-796b6c8ddf57

---

## How It Works

```mermaid
flowchart TB
    A[🖥️ You want a VPN Server] --> B{Where do you want<br/>to install?}

    B -->|Any Server<br/>AWS, DigitalOcean, VPS, etc| C[Run install.sh]
    B -->|Google Cloud<br/>Automated| D[Run gcp/run.sh deploy]

    subgraph UNIVERSAL ["🌍 Universal Installation"]
        C --> C1[SSH into your server]
        C1 --> C2[Run: curl ... install.sh]
    end

    subgraph GCP ["☁️ GCP Automated"]
        D --> D1[Select Region]
        D1 --> D2[Select Machine Type]
        D2 --> D3[Script creates VM automatically]
    end

    C2 --> E[🐳 Docker + WireGuard installed]
    D3 --> E

    E --> F[🌐 Dashboard Ready!<br/>http://IP:10086]
    F --> G[📱 Connect your devices]
```

## GCP Lifecycle

```mermaid
flowchart LR
    subgraph DEPLOY ["🚀 ./run.sh deploy"]
        A1[Create Firewall Rules] --> A2[Create VM]
        A2 --> A3[Install WireGuard]
        A3 --> A4[✅ Ready!]
    end

    subgraph MANAGE ["🔧 Management"]
        B1[status] --> B2[Check VM info]
        B3[ssh] --> B4[Connect to VM]
        B5[logs] --> B6[View logs]
        B7[stop] --> B8[Save costs 💰]
        B9[start] --> B10[Resume VM]
    end

    subgraph DESTROY ["🗑️ ./run.sh destroy"]
        C1[Remove VM] --> C2[--all: Remove firewall]
        C2 --> C3[🧹 Clean!]
    end

    A4 -.-> MANAGE
    MANAGE -.-> C1
```

---

### New Files

| File | Description |
|------|-------------|
| `scripts/deploy/install.sh` | **Universal** installation script - works on any Ubuntu/Debian server (VPS, bare metal, any cloud) |
| `scripts/deploy/gcp/run.sh` | **GCP-specific** deployment tool - automates VM creation and management on Google Cloud |
| `scripts/deploy/README.md` | Documentation |

### Features
- **One-command deployment**: `./run.sh deploy`
- **40+ global regions**: Americas, Europe, Asia Pacific, Middle East & Africa
- **Interactive selection**: Choose region and machine type with pricing info
- **Free tier support**: e2-micro instance included
- **Full management**: deploy, destroy, status, ssh, logs, start, stop commands
- **Verbose logging**: See all installation progress in real-time
- **Non-interactive installs**: No manual prompts during setup

---

## Quick Start

### Google Cloud (automated)
```bash
cd scripts/deploy/gcp

# Interactive deploy (choose region and machine type)
./run.sh deploy

# Or specify options
./run.sh deploy --project my-project --region europe-west3
```

### Any Server (manual)
```bash
# SSH into your Ubuntu/Debian server, then:
curl -O https://raw.githubusercontent.com/WGDashboard/WGDashboard/main/scripts/deploy/install.sh
sudo bash install.sh
```

## Uninstall / Destroy (GCP)

```bash
# Remove VM only
./run.sh destroy

# Remove VM + firewall rules + static IPs
./run.sh destroy --all

# Skip confirmation prompts
./run.sh destroy --all --force
```

## Test Plan

- [x] Tested deployment on GCP with e2-micro (free tier)
- [x] Tested interactive region selection
- [x] Tested interactive machine type selection
- [x] Tested destroy command with --all flag
- [x] Tested status, ssh, logs, start, stop commands
- [x] Verified non-interactive apt installs (no prompts)
- [x] Verified verbose logging output

---

More details in [scripts/deploy/README.md](https://github.com/velrino/WGDashboard/tree/feature/gcp-deploy-scripts/scripts/deploy)