### PR TITLE
Fix config info loss when renaming a tunnel.

### DIFF
--- a/src/modules/WireguardConfiguration.py
+++ b/src/modules/WireguardConfiguration.py
@@ -1058,6 +1058,11 @@ class WireguardConfiguration:
                         f'INSERT INTO "{newConfigurationName}_transfer" SELECT * FROM "{self.Name}_transfer"'
                     )
                 )
+                conn.execute(
+                    self.infoTable.update()
+                    .where(self.infoTable.c.ID == self.Name)
+                    .values(ID=newConfigurationName)
+                )
             self.AllPeerJobs.updateJobConfigurationName(self.Name, newConfigurationName)
             shutil.copy(
                 self.configPath,


### PR DESCRIPTION
This migrates data to the new tunnel when renaming, such as: Description, OverridePeerSettings, PeerGroups, PeerHistoricalEndpointTracking, PeerTrafficTracking.