### PR TITLE
Had errors on update to 4.3.3 because using double quotes in MySQL expressions triggers errors

### DIFF
--- a/src/modules/DashboardConfig.py
+++ b/src/modules/DashboardConfig.py
@@ -146,7 +146,10 @@ class DashboardConfig:
                         if col_name not in existing_columns:
                             type_str = col_type().compile(dialect=self.engine.dialect)
                             current_app.logger.info(f"Adding missing column '{col_name}' to table '{table_name}'")
-                            conn.execute(db.text(f'ALTER TABLE "{table_name}" ADD COLUMN "{col_name}" {type_str}'))
+                            preparer = self.engine.dialect.identifier_preparer
+                            quoted_table = preparer.quote_identifier(table_name)
+                            quoted_column = preparer.quote_identifier(col_name)
+                            conn.execute(db.text(f"ALTER TABLE {quoted_table} ADD COLUMN {quoted_column} {type_str}"))
 
     def getConnectionString(self, database) -> str or None:
         sqlitePath = os.path.join(DashboardConfig.ConfigurationPath, "db")


### PR DESCRIPTION
Solution: Prepare SQL Expression to right dialect quotation.