### PR TITLE
Fix config info loss when renaming a tunnel.

### DIFF
--- a/src/modules/WireguardConfiguration.py
+++ b/src/modules/WireguardConfiguration.py
@@ -1072,6 +1072,11 @@ class WireguardConfiguration:
                 doRenameStatement("_restrict_access")
                 doRenameStatement("_deleted")
                 doRenameStatement("_transfer")
+                conn.execute(
+                    self.infoTable.update()
+                    .where(self.infoTable.c.ID == self.Name)
+                    .values(ID=newConfigurationName)
+                )
 
             self.AllPeerJobs.updateJobConfigurationName(self.Name, newConfigurationName)
             shutil.copy(


### PR DESCRIPTION
This migrates data to the new tunnel when renaming, such as: Description, OverridePeerSettings, PeerGroups, PeerHistoricalEndpointTracking, PeerTrafficTracking.

Instead of [#1208](https://github.com/WGDashboard/WGDashboard/pull/1208).