### PR TITLE
change email attachmentname to peerName if not empty

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1511,7 +1511,8 @@ def API_Email_Send():
                     subject = Template(data.get('Subject', '')).render(peer=p.toJson(), configurationFile=download)
                     if data.get('IncludeAttachment', False):
                         u = str(uuid4())
-                        attachmentName = f'{u}.conf'
+                        peerName = p.toJson().get('name', '').strip()
+                        attachmentName = f'{peerName if peerName else u}.conf'
                         with open(os.path.join('./attachments', attachmentName,), 'w+') as f:
                             f.write(download['file'])   
                         

--- a/src/modules/DashboardConfig.py
+++ b/src/modules/DashboardConfig.py
@@ -146,7 +146,10 @@ class DashboardConfig:
                         if col_name not in existing_columns:
                             type_str = col_type().compile(dialect=self.engine.dialect)
                             current_app.logger.info(f"Adding missing column '{col_name}' to table '{table_name}'")
-                            conn.execute(db.text(f'ALTER TABLE "{table_name}" ADD COLUMN "{col_name}" {type_str}'))
+                            preparer = self.engine.dialect.identifier_preparer
+                            quoted_table = preparer.quote_identifier(table_name)
+                            quoted_column = preparer.quote_identifier(col_name)
+                            conn.execute(db.text(f"ALTER TABLE {quoted_table} ADD COLUMN {quoted_column} {type_str}"))
 
     def getConnectionString(self, database) -> str or None:
         sqlitePath = os.path.join(DashboardConfig.ConfigurationPath, "db")


### PR DESCRIPTION
sending an email with attachment will create the attachmentfile with the peerconfig name. is this value is empty the default will use the uuid like before.